### PR TITLE
Fix player title overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ You should see a `.env-example` file. Copy this and remove the `-example`. The f
 
 ### Starting the dev server
 
-In order to have the UI hot reload for development, we utilized `webpack-dev-server` this allows for easier debugging, etc. In order for the dev-server to connect to the API, you must first have set the `.env` file variables and have started the server with `node server.js` 
+In order to have the UI hot reload for development, we utilized `webpack-dev-server` this allows for easier debugging, etc. In order for the dev-server to connect to the API, you must first have set the `.env` file variables and have started the server with `yarn start`
 
 ```zsh
 # Install dependencies
-npm install
+yarn install
 
 # Start dev server
-npm run dev
+yarn dev
 
 # Start the node server in another terminal window.
-node server
+yarn start
 ```
 
 ## Running production

--- a/ui/src/components/Player/index.tsx
+++ b/ui/src/components/Player/index.tsx
@@ -97,7 +97,7 @@ export default class Player extends React.Component<IProps> {
             navigator.mediaSession.metadata = new MediaMetadata({
                 title: episode.title,
                 artist: episode.feedTitle,
-                ...(image && 
+                ...(image &&
                     {
                         artwork: [{ src: image, sizes: '512x512'}]
                     }
@@ -142,7 +142,7 @@ export default class Player extends React.Component<IProps> {
                             <div className="player-podcast-name">
                                 {episode.feedTitle !== undefined ?
                                     <Link to={`/podcast/${episode.feedId}`} title={episode.feedTitle}>
-                                        from: {episode.feedTitle}
+                                        {`from: ${episode.feedTitle}`}
                                     </Link>
                                     : ""
                                 }

--- a/ui/src/components/Player/styles.scss
+++ b/ui/src/components/Player/styles.scss
@@ -29,16 +29,19 @@
         margin-bottom: 5px;
         color: #2d2d2d;
     }
-    .player-podcast-name a {
-        font-size: 16px;
-        font-family: var(--font-family);
+    .player-podcast-name {
         text-align: center;
         width: 450px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        color: #2d2d2d;
         margin-bottom: 5px;
+
+        > a {
+            font-size: 16px;
+            font-family: var(--font-family);
+            color: #2d2d2d;
+        }
     }
     .player-feed-button {
         cursor: pointer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5764,6 +5764,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-js@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
+  integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
+
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz#dfdefd3254bf8a82027993674ccf35483bfcb3c5"
@@ -15758,6 +15763,11 @@ uuid@^8.0.0:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
   integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
There was clearly the intent to "ellipsify" overflowing podcast names in the player title (same as what happens to the show title). However it didn't work in practice due to some css not being applicable to anchors or other inline elements.

Before:
<img width="909" alt="Screenshot 2021-01-01 at 01 53 47" src="https://user-images.githubusercontent.com/234036/103432307-c24e6680-4bd4-11eb-9642-38fb56960ede.png">
 
After:
<img width="592" alt="Screenshot 2021-01-01 at 01 52 55" src="https://user-images.githubusercontent.com/234036/103432311-d72afa00-4bd4-11eb-9e4f-2d5bbafbb340.png">

Note that there are refactoring opportunities in the player styling - I ignored those as I was initially only trying to get the project up and running when I noticed this issue and wanted to get a quick fix in. I might return to the player in future PRs!