### PR TITLE
Update styles.scss

### DIFF
--- a/ui/src/components/Button/styles.scss
+++ b/ui/src/components/Button/styles.scss
@@ -6,6 +6,7 @@
     color: #2d2d2d;
     padding: 8px 20px;
     text-align: center;
+    white-space: nowrap;
     &:hover {
         transition: var(--transition-secs);
         background: #f2f2f2;


### PR DESCRIPTION
"Developer Login" in the header can wrap in an ugly way if the screen is between 981-1130px wide. This breaks the look/feel of the button, and shifts the rest of the page content downwards. This CSS change does not allow the UI to break between "Developer" and "Login". I can't see anywhere else where applying this to the `.button` class has any effect.