### PR TITLE
Add link to the Podcasting 2.0 page from the hero description

### DIFF
--- a/ui/src/components/TopBar/index.tsx
+++ b/ui/src/components/TopBar/index.tsx
@@ -83,9 +83,9 @@ export default class Topbar extends React.PureComponent<IProps, IState> {
                             Stats
                         </Button> */}
                         <Button href="/apps">Apps</Button>
-                        <Button href="https://blog.podcastindex.org/">
-                            Blog
-                        </Button>
+                        {/*<Button href="https://blog.podcastindex.org/">*/}
+                        {/*    Blog*/}
+                        {/*</Button>*/}
                         <Button href="https://podcastindex-org.github.io/docs-api/">
                             Documentation
                         </Button>

--- a/ui/src/pages/landing.tsx
+++ b/ui/src/pages/landing.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { Link } from 'react-router-dom'
 
 // Components
 import Button from '../components/Button'
@@ -88,7 +89,8 @@ export default class Landing extends React.Component<IProps, IState> {
                             available for free, for any use.
                         </div>
                         <h5>
-                            Listen to the first episode of "Podcasting 2.0",
+                            Listen to the first episode of
+                            "<Link to="/podcast/920666">Podcasting 2.0</Link>",
                             where we discuss the project, and its goals.
                         </h5>
                         <div className="listen-row">
@@ -188,15 +190,16 @@ export default class Landing extends React.Component<IProps, IState> {
                         </a>
                     </p>
                     <p>
-                        Follow us on the blog:{' '}
-                        <a href="https://blog.podcastindex.org/">
-                            blog.podcastindex.org
-                        </a>{' '}
-                        or on{' '}
+                        Follow us on{' '}
+                        {/*the blog:{' '}*/}
+                        {/*<a href="https://blog.podcastindex.org/">*/}
+                        {/*    blog.podcastindex.org*/}
+                        {/*</a>{' '}*/}
+                        {/*or on{' '}*/}
                         <a href="https://twitter.com/PodcastindexOrg">
                             Twitter
                         </a>
-                        , or{' '}
+                        {' '} or{' '}
                         <a href="https://noagendasocial.com/@podcastindex">
                             Mastodon
                         </a>

--- a/ui/src/pages/styles.scss
+++ b/ui/src/pages/styles.scss
@@ -17,6 +17,10 @@
     margin: auto;
     margin-top: 30px;
     margin-bottom: 80px;
+
+    a {
+        color: var(--color-primary);
+    }
 }
 
 .hero-pitch-left {


### PR DESCRIPTION
Since the podcast wasn't linked anywhere, just made the name of it a link in the hero description.

Also removed links to blog since it isn't being updated. See issue #36