### PR TITLE
Support for simple, JS free homepage

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -9,10 +9,96 @@
     </head>
 
     <body>
+        <!-- Content to show if JS is disabled -->
+        <noscript>
+            <h1>
+                <img src="/images/brand-icon.svg" alt="Podcast Index logo"/>
+                <img src="/images/brand-text.svg" alt="Podcast Index"/>
+            </h1>
+            <ul>
+                <li><a href="https://podcastindex-org.github.io/docs-api/">Documentation</a></li>
+                <li><a href="https://api.podcastindex.org/">Developer Login</a></li>
+            </ul>
+            <main id="content">
+                <p style="font-size: 30px;"><b>This website requires JavaScript to be enabled for full functionality.</b></p>
+
+                <h2>Let's preserve podcasting as a platform for free speech</h2>
+
+                <p>We do this by enabling developers to have access to an open, categorized index that will always be available for free, for any use.</p>
+
+                <p>
+                    Listen to the
+                    <a href="https://mp3s.nashownotes.com/PC20-01-2020-08-28-Final.mp3?_from=podcastindex.org">first episode</a>
+                    of "Podcasting 2.0", where we discuss the project, and its goals.
+                    <a href="http://mp3s.nashownotes.com/pc20rss.xml">Podcasting 2.0 RSS Feed</a>
+                </p>
+
+                <h3>Promise</h3>
+                <p>The core, categorized index will always be available for free, for any use.</p>
+                <h3>Operations</h3>
+                <p>
+                    Podcast Index LLC is a software developer focused partnership that provides tools and data to 
+                    anyone who aspires to create new and exciting Podcast experiences without the heavy lifting of 
+                    indexing, aggregation and data management.
+                </p>
+                <h3>Financing</h3>
+                <p>
+                    The core Podcast Index is financed by its founders and stakeholders: Podcasters, Developers and 
+                    Listeners.
+                </p>
+                <p>Corporate interests and advertising are antithetical to our business.</p>
+                <p>
+                    Podcast Index LLC strives to grow by providing enhanced API services of value to developers and
+                    organizations.
+                </p>
+                <h3>Mission and Goal</h3>
+                <p>Preserve podcasting as a platform for free speech.</p>
+                <p>
+                    Re-tool podcasting to a platform of value exchange that includes developers with podcasters and 
+                    listeners.
+                </p>
+                <h3>Developer? Join the fun!</h3>
+                <p>
+                    Sign up for an account and get API keys at: 
+                    <a href="https://api.podcastindex.org/signup">https://api.podcastindex.org</a>
+                </p>
+                <p>
+                    API Documentation is 
+                    <a target="_blank" href="https://podcastindex-org.github.io/docs-api/">here</a>.
+                </p>
+                <p>
+                    We build in the open. Get active in the 
+                    <a href="https://github.com/Podcastindex-org">Github repos</a>.
+                </p>
+                <p>
+                    We have a Mastodon server for collaboration. Join it
+                    here: 
+                    <a href="https://podcastindex.social/invite/hfcQYbjq">Podcastindex.social</a>.
+                </p>
+                <p>
+                    Follow us on <a href="https://twitter.com/PodcastindexOrg">Twitter</a> or
+                    <a href="https://noagendasocial.com/@podcastindex">Mastodon</a>.
+                </p>
+                <p>
+                    Shoot us an email at: 
+                    <a href="mailto:info@podcastindex.org">info@podcastindex.org</a>
+                </p>
+
+                <h2>Help us out...</h2>
+                <p>None of this is free. If you get any value from this project, or if you just believe in it and want
+                    to help us out with hosting fees and paying the bills, a donation of any amount would be great.</p>
+                <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+                    <input type="hidden" name="cmd" value="_s-xclick"/>
+                    <input type="hidden" name="hosted_button_id" value="9GEMYSYB7G2DW"/>
+                    <Button big primary type="submit" alt="Donate with PayPal button">Donate with Paypal</Button>
+                </form>
+            </main>
+        </noscript>
+
+        <!-- Anchor tag for node -->
         <div id="root"></div>
         <!--
       This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
 
       You can add webfonts, meta tags, or analytics to this file.
       The build step will place the bundled scripts into the <body> tag.


### PR DESCRIPTION
Add a `noscript` tag to the index page containing a simplified version of the JavaScript enabled homepage.

Resolved issue #26