### PR TITLE
Update the Apps page to show feature and platform information

### DIFF
--- a/ui/src/pages/Apps/AppsWebPart/index.tsx
+++ b/ui/src/pages/Apps/AppsWebPart/index.tsx
@@ -133,7 +133,7 @@ export default class AppsWebPart extends React.Component<
                         }
                         className="podcastIndexAppsCheckbox"
                     ></input>
-                    All
+                    <span>All</span>
                 </label>
                 {this.state.filterList.map((filter) => (
                     <span key={`checkboxArea${filter.id}`}>
@@ -149,7 +149,7 @@ export default class AppsWebPart extends React.Component<
                                 )}
                                 className="podcastIndexAppsCheckbox"
                             ></input>
-                            {filter.name}
+                            <span>{filter.name}</span>
                         </label>
                     </span>
                 ))}

--- a/ui/src/pages/Apps/AppsWebPart/index.tsx
+++ b/ui/src/pages/Apps/AppsWebPart/index.tsx
@@ -242,12 +242,16 @@ export default class AppsWebPart extends React.Component<
                             </div>
 
                             <div className="podcastIndexAppPlatforms">
-                                {app.platforms.map((platform, j) => (
-                                    <React.Fragment key={`${j}`}>
+                                {app.platforms.map((platform, j) => {
+                                  const hideNAAppPlatformOnMobile = platform === 'N/A'
+
+                                  return (
+                                    <span className={hideNAAppPlatformOnMobile ? 'hide-mobile' : ''} key={`${j}`}>
                                         {j > 0 && ', '}
                                         {platform}
-                                    </React.Fragment>
-                                ))}
+                                    </span>
+                                  )
+                                })}
                             </div>
                         </React.Fragment>
                     ))}

--- a/ui/src/pages/Apps/AppsWebPart/styles.scss
+++ b/ui/src/pages/Apps/AppsWebPart/styles.scss
@@ -127,8 +127,4 @@ $podcastIndexAppsMobileTopPadding: 30px;
       float: left;
       padding-top: $podcastIndexAppsMobileTopPadding;
     }
-
-    .hide-mobile {
-      display: none;
-    }
 }

--- a/ui/src/pages/Apps/AppsWebPart/styles.scss
+++ b/ui/src/pages/Apps/AppsWebPart/styles.scss
@@ -98,21 +98,37 @@
     line-height: 1.5;
 }
 
+$podcastIndexAppsMobileLeftMargin: 84px;
+$podcastIndexAppsMobileTopPadding: 30px;
+
 @media only screen and (max-width: 767px) {
     .podcastIndexApps {
-        display: grid;
-        column-gap: 48px;
-        grid-template-columns:
-            [image-start] 60px
-            [image-end name-start] 1fr
-            [name-end];
-        grid-template-rows: none;
-
-        margin-top: 24px;
+        display: block;
+        margin-top: 0;
     }
-    .podcastIndexAppsHeader,
-    .podcastIndexAppSupportedElements,
+    .podcastIndexAppsCheckboxArea {
+      margin-bottom: 0;
+    }
+    .podcastIndexAppsHeader {
+      display: none;
+    }
+    .podcastIndexAppTitleAndType {
+      margin-left: $podcastIndexAppsMobileLeftMargin;
+      padding-top: $podcastIndexAppsMobileTopPadding;
+    }
+    .podcastIndexAppSupportedElements {
+      margin-left: $podcastIndexAppsMobileLeftMargin;
+      margin-top: 2px;
+    }
     .podcastIndexAppPlatforms {
-        display: none;
+      margin-left: $podcastIndexAppsMobileLeftMargin;
+    }
+    .podcastIndexAppIcon {
+      float: left;
+      padding-top: $podcastIndexAppsMobileTopPadding;
+    }
+
+    .hide-mobile {
+      display: none;
     }
 }

--- a/ui/src/pages/Apps/AppsWebPart/styles.scss
+++ b/ui/src/pages/Apps/AppsWebPart/styles.scss
@@ -102,29 +102,50 @@ $podcastIndexAppsMobileLeftMargin: 84px;
 $podcastIndexAppsMobileTopPadding: 30px;
 
 @media only screen and (max-width: 767px) {
+    .podcastIndexAppsCheckboxArea label {
+        display: inline-block;
+        margin-bottom: 8px;
+
+        input[type='checkbox'] {
+            -ms-transform: scale(1.5); /* IE */
+            -moz-transform: scale(1.5); /* FF */
+            -webkit-transform: scale(1.5); /* Safari and Chrome */
+            -o-transform: scale(1.5); /* Opera */
+            transform: scale(1.5);
+        }
+
+        span {
+          display: inline-block;
+          padding-left: 5px;
+          vertical-align: text-bottom;
+        }
+    }
+
+
     .podcastIndexApps {
         display: block;
         margin-top: 0;
-    }
-    .podcastIndexAppsCheckboxArea {
-      margin-bottom: 0;
-    }
-    .podcastIndexAppsHeader {
-      display: none;
-    }
-    .podcastIndexAppTitleAndType {
-      margin-left: $podcastIndexAppsMobileLeftMargin;
-      padding-top: $podcastIndexAppsMobileTopPadding;
-    }
-    .podcastIndexAppSupportedElements {
-      margin-left: $podcastIndexAppsMobileLeftMargin;
-      margin-top: 2px;
-    }
-    .podcastIndexAppPlatforms {
-      margin-left: $podcastIndexAppsMobileLeftMargin;
-    }
-    .podcastIndexAppIcon {
-      float: left;
-      padding-top: $podcastIndexAppsMobileTopPadding;
+
+        .podcastIndexAppsCheckboxArea {
+            margin-bottom: 0;
+        }
+        .podcastIndexAppsHeader {
+            display: none;
+        }
+        .podcastIndexAppTitleAndType {
+            margin-left: $podcastIndexAppsMobileLeftMargin;
+            padding-top: $podcastIndexAppsMobileTopPadding;
+        }
+        .podcastIndexAppSupportedElements {
+            margin-left: $podcastIndexAppsMobileLeftMargin;
+            margin-top: 2px;
+        }
+        .podcastIndexAppPlatforms {
+            margin-left: $podcastIndexAppsMobileLeftMargin;
+        }
+        .podcastIndexAppIcon {
+            float: left;
+            padding-top: $podcastIndexAppsMobileTopPadding;
+        }
     }
 }

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -84,4 +84,7 @@ h4 {
     .landing-graphic {
         display: none;
     }
+    .hide-mobile {
+      display: none;
+    }
 }


### PR DESCRIPTION
I have disabled the CSS grid rules for mobile screens in order to make the feature and platform info render cleanly below each app. This is kind of hacky, but since the changes are exclusively CSS rules and doesn't affect the layout (except for hiding the "N/A" value on mobile), I thought maybe this is an acceptable approach for now.

![image](https://user-images.githubusercontent.com/2262919/105756227-f423c600-5f11-11eb-956f-a82d4f568832.png)

![image](https://user-images.githubusercontent.com/2262919/105756246-fa19a700-5f11-11eb-975f-e76b7b526d34.png)

Desktop should still look the same:

![image](https://user-images.githubusercontent.com/2262919/105756280-04d43c00-5f12-11eb-9290-f4ffa86eb73c.png)