### PR TITLE
Add value display to podcast info

### DIFF
--- a/ui/src/components/PodcastHeader/index.tsx
+++ b/ui/src/components/PodcastHeader/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import NoImage from '../../../images/no-cover-art.png'
-import {truncateString} from '../../utils'
+import { truncateString, titleizeString } from '../../utils'
 import RSSLogo from "../../../images/feed.svg";
 import EarthLogo from "../../../images/earth.svg";
 import './styles.scss'
@@ -15,6 +15,19 @@ interface IProps {
     id?: string
     feedURL?: string
     podcastURL?: string
+    value?: {
+      model: {
+        type: string
+        method: string
+        suggested: string
+      }
+      destinations?: Array<{
+        name: string
+        type: string
+        address: string
+        split: string
+      }>
+    }
 }
 
 export default class PodcastHeader extends React.PureComponent<IProps> {
@@ -45,7 +58,8 @@ export default class PodcastHeader extends React.PureComponent<IProps> {
     }
 
     render() {
-        const {title, description, author, categories, image, feedURL, podcastURL} = this.props
+        const {title, description, author, categories, image, feedURL, podcastURL, value} = this.props
+        const splitTotal = value && value.destinations ? value && value.destinations.reduce((total, d) => total + parseInt(d.split, 10), 0): null
         return (
             <div className="podcast-header">
                 <h1 className="podcast-header-title">{title}</h1>
@@ -90,6 +104,18 @@ export default class PodcastHeader extends React.PureComponent<IProps> {
                                 : ""
                             }
                         </div>
+                        {value && value.destinations &&
+                          <div className="podcast-value">
+                            <h4>Value for Value via {titleizeString(value.model.type)}</h4>
+                            <ul>
+                              {value.destinations.map(dest => (
+                                <li>
+                                  <progress value={dest.split} max={splitTotal}></progress> {dest.name}
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        }
                     </div>
                 </div>
             </div>

--- a/ui/src/components/PodcastHeader/styles.scss
+++ b/ui/src/components/PodcastHeader/styles.scss
@@ -99,6 +99,50 @@
     //padding: 10px;
 }
 
+.podcast-value {
+  font-size: 18px;
+
+  h4 {
+    font-size: 18px;
+    margin-bottom: .5rem;
+  }
+
+  ul {
+    margin: 0 0 1.5rem;
+    padding-left: 0;
+
+    li {
+      display: flex;
+      align-items: center;
+      margin: .25rem 0;
+    }
+  }
+
+  progress[value] {
+    appearance: none;
+    border: 0;
+    border-radius: .25rem;
+    width: 100px;
+    height: 1rem;
+    margin-right: .5rem;
+  }
+
+  progress[value]::-webkit-progress-bar {
+    background-color: #eee;
+    border-radius: .25rem;
+  }
+
+  // though both use the same styles, it does not work as a combined selector!
+  progress[value]::-webkit-progress-value {
+    background-color: var(--color-primary);
+    border-radius: .25rem;
+  }
+  progress[value]::-moz-progress-bar {
+    background-color: var(--color-primary);
+    border-radius: .25rem;
+  }
+}
+
 @media only screen and (max-width: 767px) {
     /* phones */
     .podcast-header-row {
@@ -146,7 +190,9 @@
         border: 1px solid #cecece;
         border-radius: 5px;
         margin: 3px;
-
         padding: 4px 12px;
+    }
+    .podcast-value {
+        font-size: 14px;
     }
 }

--- a/ui/src/pages/Podcast/PodcastInfo/index.tsx
+++ b/ui/src/pages/Podcast/PodcastInfo/index.tsx
@@ -144,6 +144,7 @@ export default class PodcastInfo extends React.PureComponent<IProps> {
         let author = this.state.result.author
         let description = this.state.result.description
         let categories = this.state.result.categories
+        let value = this.state.result.value
         let id = this.state.result.id
         let podcastURL = this.state.result.link
         let feedURL = this.state.result.url
@@ -156,6 +157,7 @@ export default class PodcastInfo extends React.PureComponent<IProps> {
                 image={image}
                 description={description}
                 categories={categories}
+                value={value}
                 id={id}
                 podcastURL={podcastURL}
                 feedURL={feedURL}

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -23,6 +23,13 @@ export const truncateString = (input: string) => {
         return input
 }
 
+export const titleizeString = (input: string) => {
+  return input
+    .split(/\W+/gi)
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
 export const getPrettyDate = (time: number, includeTime: boolean = true) => {
     // Javascript epoch is in milliseconds; datePublished is in seconds
     const dateObj = new Date(time*1000)
@@ -30,4 +37,3 @@ export const getPrettyDate = (time: number, includeTime: boolean = true) => {
         return dateObj.toLocaleString()
     return dateObj.toLocaleDateString()
 }
-


### PR DESCRIPTION
Displays the value block on the podcast info page if it is present. I find this to be valuable information (pun intended), for the listener as well as for feed debugging purposes :)

## Examples

![podcast-value](https://user-images.githubusercontent.com/886/112814820-f6c0aa00-907f-11eb-8c4a-ce3c78419686.png)

![podcasting20](https://user-images.githubusercontent.com/886/112816272-8581f680-9081-11eb-9ef9-ecc30838e1f5.png)

![slp](https://user-images.githubusercontent.com/886/112816444-b82bef00-9081-11eb-98dc-7f243f21cfe7.png)

![tftc](https://user-images.githubusercontent.com/886/112816624-e3164300-9081-11eb-8170-d624684cc4cb.png)

