### PR TITLE
Move link color style for apps page to global styles so that links are consistent on site

### DIFF
--- a/ui/src/components/TopBar/styles.scss
+++ b/ui/src/components/TopBar/styles.scss
@@ -49,6 +49,12 @@ a,
         display: inline-flex;
         flex-direction: row;
     }
+
+    a:link,
+    a:visited,
+    a:active{
+        color: #2d2d2d;
+    }
 }
 
 .topbar-mobile-dropdown {

--- a/ui/src/pages/Apps/AppsWebPart/styles.scss
+++ b/ui/src/pages/Apps/AppsWebPart/styles.scss
@@ -42,17 +42,6 @@
     grid-template-rows: 30px;
 
     margin-top: 24px;
-
-    a:link,
-    a:visited,
-    a:active {
-        display: inline-block;
-        color: #002752;
-    }
-
-    a:hover {
-        color: #cc2799;
-    }
 }
 
 .podcastIndexAppsHeader {

--- a/ui/src/pages/Apps/styles.scss
+++ b/ui/src/pages/Apps/styles.scss
@@ -1,15 +1,3 @@
-.contribute-notes {
-    a:link,
-    a:visited,
-    a:active {
-        color: #002752;
-    }
-
-    a:hover {
-        color: #cc2799;
-    }
-}
-
 .csb {
     background-color: darkolivegreen;
     color: yellow;

--- a/ui/src/pages/styles.scss
+++ b/ui/src/pages/styles.scss
@@ -17,10 +17,6 @@
     margin: auto;
     margin-top: 30px;
     margin-bottom: 80px;
-
-    a {
-        color: var(--color-primary);
-    }
 }
 
 .hero-pitch-left {

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -71,6 +71,16 @@ h4 {
     font-size: 27px;
 }
 
+a:link,
+a:visited,
+a:active {
+    color: #002752;
+}
+
+a:hover {
+    color: #cc2799;
+}
+
 .landing-graphic {
     opacity: 0.75;
     top: 120px;


### PR DESCRIPTION
This was suggested by @dennisreimann in PR #53 .

I like the idea but find the color used on the apps page kind of gets lost on the homepage. Feel free to update or propose different colors. 

Current:

![current](https://user-images.githubusercontent.com/677342/113248417-c9d3e900-9271-11eb-88fe-b8c8c42c6d60.PNG)

Using colors from apps page:

![apps](https://user-images.githubusercontent.com/677342/113248416-c93b5280-9271-11eb-9a1f-a1baaed3968a.PNG)
