### PR TITLE
Podcast page loading issue

### DIFF
--- a/ui/src/components/EpisodeItem/index.tsx
+++ b/ui/src/components/EpisodeItem/index.tsx
@@ -78,7 +78,6 @@ export default class EpisodeItem extends React.PureComponent<IProps> {
         const date = getPrettyDate(datePublished)
         const episodeLink = link
         const episodeEnclosure = enclosureUrl
-        console.log(this)
         return (
             <div className="episode">
                 <div className="episode-row">

--- a/ui/src/components/PodcastHeader/index.tsx
+++ b/ui/src/components/PodcastHeader/index.tsx
@@ -114,7 +114,7 @@ export default class PodcastHeader extends React.PureComponent<IProps> {
                             <h4>Value for Value via {titleizeString(value.model.type)}</h4>
                             <ul>
                               {value.destinations.map(dest => (
-                                <li>
+                                <li key={dest.name}>
                                   <progress value={dest.split} max={splitTotal}></progress> {dest.name}
                                 </li>
                               ))}

--- a/ui/src/pages/Podcast/PodcastInfo/index.tsx
+++ b/ui/src/pages/Podcast/PodcastInfo/index.tsx
@@ -232,7 +232,7 @@ export default class PodcastInfo extends React.PureComponent<IProps> {
 
     render() {
         const { loading, result, episodes } = this.state
-        if ((result === undefined || episodes.length === 0) && !loading) {
+        if ((result === undefined || result.length === 0 || episodes.length === 0) && !loading) {
             const errorMessage = `Unknown podcast ID: ${this.props.match.params.podcastId}`
             updateTitle(errorMessage)
             return <div className="page-content">{errorMessage}</div>


### PR DESCRIPTION
Fix podcast page loading to handle case where no feed is found by `podcasts/byfeedid` but episodes are found by `episodes/byfeedid`.

This was found after whatever Dave did to remove a podcast hosted on a gists page. See https://podcastindex.social/@js/105985955290085608