### PR TITLE
Use amboss instead of 1ml

### DIFF
--- a/ui/src/components/PodcastHeader/index.tsx
+++ b/ui/src/components/PodcastHeader/index.tsx
@@ -160,7 +160,7 @@ export default class PodcastHeader extends React.PureComponent<IProps, PodState>
                             <ul>
                               {value.destinations.map(dest => (
                                 <li key={dest.name}>
-                                    <progress value={dest.split} max={splitTotal} title={dest.address}></progress> <a target="_blank" href={"https://1ml.com/node/"+dest.address}>{dest.name}</a>
+                                    <progress value={dest.split} max={splitTotal} title={dest.address}></progress> <a target="_blank" href={"https://amboss.space/node/"+dest.address}>{dest.name}</a>
                                 </li>
                               ))}
                             </ul>


### PR DESCRIPTION
Amboss.space is a new explorer. Where 1ml has not had updates for years, amboss.space is a great explorer, actively developed, and shows much better info, such as readable fee reports.