### PR TITLE
Add value 4 value info on episode level

### DIFF
--- a/ui/src/components/EpisodeItem/index.tsx
+++ b/ui/src/components/EpisodeItem/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import {getPrettyDate, truncateString} from '../../utils'
 
+import Value from '../Value'
 import NoImage from '../../../images/no-cover-art.png'
 import PlayLogo from '../../../images/play-circle.svg'
 import PauseLogo from '../../../images/pause-circle.svg'
@@ -9,12 +10,12 @@ import DownloadLogo from '../../../images/download-outline.svg'
 
 import './styles.scss'
 
-
 interface IProps {
     index?: number
     title?: string
     image?: any
-    link?: string
+    link?: string,
+    value?: any,
     enclosureUrl?: string
     description?: string
     datePublished?: number
@@ -74,10 +75,11 @@ export default class EpisodeItem extends React.PureComponent<IProps> {
     }
 
     render() {
-        const {title, image, link, enclosureUrl, description, datePublished} = this.props
+        const {title, image, link, value, enclosureUrl, description, datePublished} = this.props
         const date = getPrettyDate(datePublished)
         const episodeLink = link
         const episodeEnclosure = enclosureUrl
+
         return (
             <div className="episode">
                 <div className="episode-row">
@@ -142,6 +144,7 @@ export default class EpisodeItem extends React.PureComponent<IProps> {
                 <p className="episode-description">
                     {truncateString(description).replace(/(<([^>]+)>)/gi, " ")}
                 </p>
+                {value && <Value {...value} />}
             </div>
         )
     }

--- a/ui/src/components/EpisodeItem/styles.scss
+++ b/ui/src/components/EpisodeItem/styles.scss
@@ -84,6 +84,10 @@
     padding: 10px;
 }
 
+.episode .podcast-value {
+  padding: 10px;
+}
+
 @media only screen and (max-width: 767px) {
     /* phones */
     .episode-row {

--- a/ui/src/components/PodcastHeader/index.tsx
+++ b/ui/src/components/PodcastHeader/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 
+import Value from '../Value'
 import NoImage from '../../../images/no-cover-art.png'
 import { truncateString, titleizeString } from '../../utils'
 import RSSLogo from "../../../images/feed.svg";
@@ -154,18 +155,7 @@ export default class PodcastHeader extends React.PureComponent<IProps, PodState>
                                 : ""
                             }
                         </div>
-                        {value && value.destinations &&
-                          <div className="podcast-value">
-                            <h4>Value for Value via {titleizeString(value.model.type)}</h4>
-                            <ul>
-                              {value.destinations.map(dest => (
-                                <li key={dest.name}>
-                                    <progress value={dest.split} max={splitTotal} title={dest.address}></progress> <a target="_blank" href={"https://amboss.space/node/"+dest.address}>{dest.name}</a>
-                                </li>
-                              ))}
-                            </ul>
-                          </div>
-                        }
+                        {value && <Value {...value} />}
                     </div>
                 </div>
             </div>

--- a/ui/src/components/PodcastHeader/styles.scss
+++ b/ui/src/components/PodcastHeader/styles.scss
@@ -106,48 +106,8 @@
     //padding: 10px;
 }
 
-.podcast-value {
-  font-size: 18px;
-
-  h4 {
-    font-size: 18px;
-    margin-bottom: .5rem;
-  }
-
-  ul {
-    margin: 0 0 1.5rem;
-    padding-left: 0;
-
-    li {
-      display: flex;
-      align-items: center;
-      margin: .25rem 0;
-    }
-  }
-
-  progress[value] {
-    appearance: none;
-    border: 0;
-    border-radius: .25rem;
-    width: 100px;
-    height: 1rem;
-    margin-right: .5rem;
-  }
-
-  progress[value]::-webkit-progress-bar {
-    background-color: #eee;
-    border-radius: .25rem;
-  }
-
-  // though both use the same styles, it does not work as a combined selector!
-  progress[value]::-webkit-progress-value {
-    background-color: var(--color-primary);
-    border-radius: .25rem;
-  }
-  progress[value]::-moz-progress-bar {
-    background-color: var(--color-primary);
-    border-radius: .25rem;
-  }
+.podcast-header .podcast-value {
+  padding: 10px 0;
 }
 
 @media only screen and (max-width: 767px) {
@@ -198,8 +158,5 @@
         border-radius: 5px;
         margin: 3px;
         padding: 4px 12px;
-    }
-    .podcast-value {
-        font-size: 14px;
     }
 }

--- a/ui/src/components/Value/index.tsx
+++ b/ui/src/components/Value/index.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+
+import { titleizeString } from '../../utils'
+import './styles.scss'
+
+interface IProps {
+  model: {
+    type: string
+    method: string
+    suggested: string
+  }
+  destinations?: Array<{
+    name: string
+    type: string
+    address: string
+    split: string
+  }>
+}
+
+type PodState = { copyMessage: string };
+
+export default class Value extends React.PureComponent<IProps, PodState> {
+
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const { destinations, model } = this.props
+    const splitTotal = destinations ? destinations.reduce((total, d) => total + parseInt(d.split, 10), 0) : null
+
+    if (destinations && destinations.length > 1 && destinations[(destinations.length - 1)].name.toLowerCase() === "podcastindex.org") {
+      destinations.pop();
+    }
+
+    return (
+      <div className="podcast-value">
+        <h4>Value for Value via {titleizeString(model.type)}</h4>
+        <ul>
+          {destinations.map(dest => (
+            <li key={dest.name}>
+              <progress value={dest.split} max={splitTotal} title={dest.address}></progress> <a target="_blank" href={"https://amboss.space/node/" + dest.address}>{dest.name}</a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    )
+  }
+}

--- a/ui/src/components/Value/styles.scss
+++ b/ui/src/components/Value/styles.scss
@@ -1,0 +1,49 @@
+.podcast-value {
+  font-size: 18px;
+
+  h4 {
+    font-size: 18px;
+    margin: 0 0 .5rem;
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 0;
+
+    li {
+      display: flex;
+      align-items: center;
+      margin: .25rem 0;
+    }
+  }
+
+  progress[value] {
+    appearance: none;
+    border: 0;
+    border-radius: .25rem;
+    width: 100px;
+    height: 1rem;
+    margin-right: .5rem;
+  }
+
+  progress[value]::-webkit-progress-bar {
+    background-color: #eee;
+    border-radius: .25rem;
+  }
+
+  // though both use the same styles, it does not work as a combined selector!
+  progress[value]::-webkit-progress-value {
+    background-color: var(--color-primary);
+    border-radius: .25rem;
+  }
+  progress[value]::-moz-progress-bar {
+    background-color: var(--color-primary);
+    border-radius: .25rem;
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .podcast-value {
+    font-size: 14px;
+  }
+}

--- a/ui/src/pages/Podcast/PodcastInfo/index.tsx
+++ b/ui/src/pages/Podcast/PodcastInfo/index.tsx
@@ -227,6 +227,7 @@ export default class PodcastInfo extends React.PureComponent<IProps> {
         let enclosureUrl = fixURL(this.state.episodes[index].enclosureUrl)
         let description = he.decode(this.state.episodes[index].description)
         let datePublished = this.state.episodes[index].datePublished
+        let value = this.state.episodes[index].value
 
         // create a reference to the generated EpisodeItem if one doesn't already exist
         if (index >= this.episodeItems.length) {
@@ -241,6 +242,7 @@ export default class PodcastInfo extends React.PureComponent<IProps> {
                     title={title}
                     image={image}
                     link={link}
+                    value={value}
                     enclosureUrl={enclosureUrl}
                     description={description}
                     datePublished={datePublished}


### PR DESCRIPTION
Extracts the `Value` component and adds it to the `EpisodeItem` if the episode has v4v info.

Here's an example with one episode with and one without that info:

![episode-value4value](https://user-images.githubusercontent.com/886/135925950-96cd3fad-29ce-4f0a-b281-f98901720c4a.png)


