### PR TITLE
Don't preload audio for HTML5 audio player

### DIFF
--- a/ui/src/components/Player/index.tsx
+++ b/ui/src/components/Player/index.tsx
@@ -165,7 +165,7 @@ export default class Player extends React.Component<IProps> {
                     src={enclosureUrl}
                     onCanPlay={this.onCanPlay}
                     onPlay={this.onPlay}
-                    preload="metadata"
+                    preload="none"
                     onPause={this.onPause}
                     onEnded={this.onPause}
                     customAdditionalControls={[


### PR DESCRIPTION
`preload="metadata"` still seems to load a significant amount of data which may artificially inflate downloads under the IAB podcast measurement guidelines.

![image](https://user-images.githubusercontent.com/484912/144341003-4d48139d-4540-46fe-8d48-67f6e5491b83.png)