### PR TITLE
Add Fountain Web Tag

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -121,7 +121,7 @@
         "platforms": [
             "iOS",
             "Android",
-            "web"
+            "Web"
         ],
         "supportedElements": [
             {

--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -120,7 +120,8 @@
         "appIconUrl": "fountain.png",
         "platforms": [
             "iOS",
-            "Android"
+            "Android",
+            "web"
         ],
         "supportedElements": [
             {


### PR DESCRIPTION
Added Fountain web support tag - we now have playable show and episode links with persistent player at the bottom of the page:

- Show Link - https://play.fountain.fm/show/QRT0l2EfrKXNGDlRrmjL
- Episode Link - https://play.fountain.fm/episode/5874073954

More web features coming soon!