### PR TITLE
Add web to Podcast Guru on Podcast Index - apps page #125

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -199,6 +199,7 @@
         "appIconUrl": "podcastguru.jpg",
         "platforms": [
             "Android",
+            "Web",
             "iOS"
         ],
         "supportedElements": [


### PR DESCRIPTION
Add "Web" to Podcast Guru entry on apps page as according to:
https://podcastguru.io/news/podcastguru-web-app/
This is now an option.

Fixes #125 