### PR TITLE
Refactoring: Use state to show the Apps filter property buttons

### DIFF
--- a/ui/src/pages/Apps/AppsWebPart/FilterTags/index.tsx
+++ b/ui/src/pages/Apps/AppsWebPart/FilterTags/index.tsx
@@ -160,6 +160,21 @@ function FilterTags({ apps, setFilteredApps, filterTypes }) {
         })
     }
 
+    /**
+     * Format the tag name for display in the UI by capitalizing 
+     * the first letter of each word in the tag (i.e. podcast player => Podcast Player)
+     */
+    function formatTagName(tag: string): string {
+        return tag
+            .split(' ')
+            .map(
+                (v) =>
+                    v.charAt(0).toUpperCase() +
+                    v.slice(1)
+            )
+            .join(' ')
+    }
+
     return (
         <div className="podcastIndexAppsFilterTagContainer">
             <h4 onClick={toggleFilters}>
@@ -190,14 +205,7 @@ function FilterTags({ apps, setFilteredApps, filterTypes }) {
                                     data-type={key}
                                     data-tag={tag}
                                 >
-                                    {tag
-                                        .split(' ')
-                                        .map(
-                                            (v) =>
-                                                v.charAt(0).toUpperCase() +
-                                                v.slice(1)
-                                        )
-                                        .join(' ')}
+                                    {formatTagName(tag)}
                                 </button>
                             ))}
                         </div>

--- a/ui/src/pages/Apps/AppsWebPart/FilterTags/styles.scss
+++ b/ui/src/pages/Apps/AppsWebPart/FilterTags/styles.scss
@@ -23,12 +23,12 @@
             background: #b3b2b2;
         }
     }
-    &[data-tag='Clear'] {
+    &.clear-button {
         width: 47.88px;
         background-color: #aa0000;
         color: white;
     }
-    &[data-tag='Clear']:hover {
+    &.clear-button:hover {
         background-color: darken($color: #aa0000, $amount: 5%);
     }
 }


### PR DESCRIPTION
The filter buttons on the Apps UI were not drawn or updated based on state. This commit changes that.

Since the logic for all filter types is the same, to avoid multiple state and state setter "ifs", I hidden that behind functions that get the filter state and filter state setters.

I also separated the Clear button from the list of tags.