### PR TITLE
Show that Castamatic supports Boostagrams

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -643,6 +643,10 @@
     ],
     "supportedElements": [
       {
+        "elementName": "Boostagrams",
+        "elementURL": "https://itunes.apple.com/it/app/castamatic-podcast-player/id966632553?mt=8"
+      },
+      {
         "elementName": "Value",
         "elementURL": "https://itunes.apple.com/it/app/castamatic-podcast-player/id966632553?mt=8"
       },


### PR DESCRIPTION
It has at least since v8, which I have been running for a month or so now.