### PR TITLE
Fix tallycoin widget not loading after navigating to a different page and then back home

### DIFF
--- a/ui/src/components/TallyCoinWidget/index.tsx
+++ b/ui/src/components/TallyCoinWidget/index.tsx
@@ -7,25 +7,53 @@ interface IProps {
 }
 
 export default class TallyCoinWidget extends React.PureComponent<IProps> {
+    tallypayRef = React.createRef<HTMLDivElement>()
     static defaultProps = {
         theme: "light",
     }
+
     constructor(props: IProps) {
         super(props)
     }
 
     componentDidMount() {
-        // load the external script
-        const script = document.createElement('script')
-        script.src = 'https://tallyco.in/js/tallypay.js'
-        script.async = true
-        document.head.appendChild(script)
+        this.triggerWidget()
+    }
+
+    addScript() {
+        const scriptAdded = document.getElementById('tallycoin-script')
+
+        if (scriptAdded === null) {
+            // load the external script
+            const script = document.createElement('script')
+            script.src = 'https://tallyco.in/js/tallypay.js'
+            script.async = true
+            script.id = 'tallycoin-script'
+            document.head.appendChild(script)
+        }
+    }
+
+    triggerWidget() {
+        this.addScript()
+
+        if (this.tallypayRef.current) {
+            if (this.tallypayRef.current.childElementCount === 0) {
+                try {
+                    // call start function in tallypay.js
+                    // @ts-ignore
+                    window.init_tallypay_widget()
+                } catch (e) {
+                }
+            }
+        }
+
     }
 
     render() {
         const {theme} = this.props
         return (
             <div
+                ref={this.tallypayRef}
                 className="tallypay"
                 data-user="podcastindex"
                 data-theme={theme}


### PR DESCRIPTION
This may break if tallycoin updates their JavaScript. 

The issue is that the script only runs on `window.onload`. This only happens the first page load. By watching for the component to load, we call the `init_tallypay_widget` function in the external JS.

If there is a better way to do this, let me know.