### PR TITLE
Enhancement #139: Apps filtering based on URL search (query) parameters

### DIFF
--- a/ui/src/pages/Apps/AppsWebPart/FilterTags/index.tsx
+++ b/ui/src/pages/Apps/AppsWebPart/FilterTags/index.tsx
@@ -16,6 +16,7 @@ function FilterTags({ apps, setFilteredApps, filterTypes }) {
         appTypeFilters,
         supportedElementsFilters,
         platformsFilters,
+        apps
     ])
 
     function expandOrCollapseFilters() {

--- a/ui/src/pages/Apps/AppsWebPart/FilterTags/index.tsx
+++ b/ui/src/pages/Apps/AppsWebPart/FilterTags/index.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react'
-import { useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import './styles.scss'
 
 function FilterTags({ apps, setFilteredApps, filterTypes }) {
     const query = useUrlSearchParams();
+    const history = useHistory();
     const [appTypeFilters, setAppTypeFilters] = useState(new Set() as Set<string>)
     const [supportedElementsFilters, setSupportedElementsFilters] = useState(
         new Set() as Set<string>
@@ -21,7 +22,7 @@ function FilterTags({ apps, setFilteredApps, filterTypes }) {
         apps
     ])
 
-    useEffect(setFiltersFromUrlSearchParams, [])
+    useEffect(setFiltersFromUrlSearchParams, [query])
 
     function useUrlSearchParams() {
         const { search } = useLocation();
@@ -57,6 +58,39 @@ function FilterTags({ apps, setFilteredApps, filterTypes }) {
             const filterValues = paramValue.split(',')
             filterStateSetter(new Set(filterValues));
         }
+        else {
+            filterStateSetter(new Set());
+        }
+    }
+
+    function updateLocationURLSearchParameters(filterType: string, filterValue: Set<string>) {
+        const filtersStateCopy = {
+            appTypeFilters: new Set(appTypeFilters),
+            supportedElementsFilters: new Set(supportedElementsFilters),
+            platformsFilters: new Set(platformsFilters)
+        }
+
+        switch(filterType) {
+            case 'appType':
+                filtersStateCopy.appTypeFilters = filterValue;
+                break;
+            case 'supportedElements':
+                filtersStateCopy.supportedElementsFilters = filterValue;
+                break;
+            case 'platforms':
+                filtersStateCopy.platformsFilters = filterValue;
+                break;
+        }
+
+        const search = new URLSearchParams({
+            ...(filtersStateCopy.appTypeFilters.size && {appTypes: Array.from(filtersStateCopy.appTypeFilters).join(',')}),
+            ...(filtersStateCopy.supportedElementsFilters.size && {elements: Array.from(filtersStateCopy.supportedElementsFilters).join(',')}),
+            ...(filtersStateCopy.platformsFilters.size && {platforms: Array.from(filtersStateCopy.platformsFilters).join(',')}),
+        }).toString();
+        
+        history.push({
+            search: search? '?' + search : ''
+        })
     }
 
     function filterApps() {
@@ -108,22 +142,10 @@ function FilterTags({ apps, setFilteredApps, filterTypes }) {
         }
     }
 
-    function getFilterStateSetterByType(type: string): React.Dispatch<React.SetStateAction<Set<string>>> {
-        switch(type) {
-            default:
-            case 'appType': 
-                return setAppTypeFilters;
-            case 'supportedElements':
-                return setSupportedElementsFilters;
-            case 'platforms':
-                return setPlatformsFilters;
-        }
-    }
-
     function handleClearClick(e: React.MouseEvent<HTMLButtonElement>) {
-        const type = e.currentTarget.getAttribute('type') as string
+        const type = e.currentTarget.getAttribute('data-type') as string
 
-        getFilterStateSetterByType(type)(new Set());
+        updateLocationURLSearchParameters(type, new Set())
     }
 
     function handleTagClick(e) {
@@ -138,7 +160,7 @@ function FilterTags({ apps, setFilteredApps, filterTypes }) {
             filterStateCopy.add(tag)
         }
 
-        getFilterStateSetterByType(type)(filterStateCopy);
+        updateLocationURLSearchParameters(type, filterStateCopy)
     }
 
     function toggleFilters() {
@@ -214,7 +236,8 @@ function FilterTags({ apps, setFilteredApps, filterTypes }) {
                             <div>{type}</div>
                             <button 
                                 className="clear-button" 
-                                onClick={handleClearClick}>
+                                onClick={handleClearClick}
+                                data-type={key}>
                                     Clear
                             </button>
                             {[

--- a/ui/src/pages/Apps/AppsWebPart/FilterTags/index.tsx
+++ b/ui/src/pages/Apps/AppsWebPart/FilterTags/index.tsx
@@ -10,11 +10,28 @@ function FilterTags({ apps, setFilteredApps, filterTypes }) {
     const [platformsFilters, setPlatformsFilters] = useState(new Set() as Set<string>)
     const [filtersExpanded, setFiltersExpanded] = useState(false);
 
+    useEffect(expandOrCollapseFilters, [filtersExpanded])
+
     useEffect(filterApps, [
         appTypeFilters,
         supportedElementsFilters,
         platformsFilters,
     ])
+
+    function expandOrCollapseFilters() {
+        const container = document.querySelector(
+            '.podcastIndexAppsFilterCategories'
+        ) as HTMLElement
+
+        // The collapse and expand functions are requires because
+        // it is not possible to animate to height: auto with CSS
+        // more at https://carlanderson.xyz/how-to-animate-on-height-auto/
+        if (filtersExpanded) {
+            expandSection(container)
+        } else {
+            collapseSection(container)
+        }
+    }
 
     function filterApps() {
         let filteredApps = filterAppType(
@@ -98,20 +115,7 @@ function FilterTags({ apps, setFilteredApps, filterTypes }) {
         getFilterStateSetterByType(type)(filterStateCopy);
     }
 
-    function toggleFilters(e) {
-        const container = document.querySelector(
-            '.podcastIndexAppsFilterCategories'
-        ) as HTMLElement
-
-        // The collapse and expand functions are requires because
-        // it is not possible to animate to height: auto with CSS
-        // more at https://carlanderson.xyz/how-to-animate-on-height-auto/
-        if (filtersExpanded) {
-            collapseSection(container)
-        } else {
-            expandSection(container)
-        }
-
+    function toggleFilters() {
         setFiltersExpanded(!filtersExpanded)
     }
 

--- a/ui/src/pages/Apps/AppsWebPart/FilterTags/index.tsx
+++ b/ui/src/pages/Apps/AppsWebPart/FilterTags/index.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from 'react'
+import { useLocation } from 'react-router-dom';
 
 import './styles.scss'
 
 function FilterTags({ apps, setFilteredApps, filterTypes }) {
+    const query = useUrlSearchParams();
     const [appTypeFilters, setAppTypeFilters] = useState(new Set() as Set<string>)
     const [supportedElementsFilters, setSupportedElementsFilters] = useState(
         new Set() as Set<string>
@@ -19,6 +21,14 @@ function FilterTags({ apps, setFilteredApps, filterTypes }) {
         apps
     ])
 
+    useEffect(setFiltersFromUrlSearchParams, [])
+
+    function useUrlSearchParams() {
+        const { search } = useLocation();
+    
+        return React.useMemo(() => new URLSearchParams(search), [search]);
+    }
+
     function expandOrCollapseFilters() {
         const container = document.querySelector(
             '.podcastIndexAppsFilterCategories'
@@ -31,6 +41,21 @@ function FilterTags({ apps, setFilteredApps, filterTypes }) {
             expandSection(container)
         } else {
             collapseSection(container)
+        }
+    }
+
+    function setFiltersFromUrlSearchParams() {
+        setFiltersFromUrlSearchParam('appTypes', setAppTypeFilters);
+        setFiltersFromUrlSearchParam('elements', setSupportedElementsFilters);
+        setFiltersFromUrlSearchParam('platforms', setPlatformsFilters);
+    }
+
+    function setFiltersFromUrlSearchParam(paramName: string, filterStateSetter:  React.Dispatch<React.SetStateAction<Set<string>>>) {
+        const paramValue = query.get(paramName)
+
+        if(paramValue) {
+            const filterValues = paramValue.split(',')
+            filterStateSetter(new Set(filterValues));
         }
     }
 

--- a/ui/src/pages/Apps/AppsWebPart/index.tsx
+++ b/ui/src/pages/Apps/AppsWebPart/index.tsx
@@ -50,9 +50,6 @@ function AppsWebPart() {
         getApps(setApps, setFilterTypes)
     }, [])
 
-    useEffect(() => {
-        setFilteredApps(apps)
-    }, [apps])
     return (
         <div className="podcastIndexAppsWebPart">
             <FilterTags


### PR DESCRIPTION
This PR introduces URL Search (query) Parameters to represent the filters selected by the user.
With this, it is possible to share a URL that leads to a pre-filtered list of apps.

## Implementation notes

Now when a user clicks a filter button, the state is not directly updated, but only indirectly as a reaction to the change in the
URL Search Params.

Updating both the URL Search Parameters and the state was tested, but not only it was unnecessary, it caused undesired side effects, causing sometimes infinite render loops.

## Leftovers

When you access a URL with filters, the filters div is not automatically expanded - I could not manage to implement the expansion of the filters on first render, the `scrollHeight` was still `0`. Even if that was possible, the state of it (collapsed/expanded) should not be simply derived from having or not filters, so it would have to also be represented as a URL parameter, and I decided not to implement that in this PR.

## Fixes

This PR also fixes an issue introduced with https://github.com/Podcastindex-org/web-ui/pull/142.

The _Clear_ button was not working anymore.

## Note to Reviewer

At the end there were a lot of changes, but the messages on the commit messages can give a more granular information on what each change is about.

I tested the history going back and forward, as far as I could tell, that is working well. 

## To Do

- [x] Update the URL Search Parameters when there is a change in filter selection - 19b0ec8cd53e5d3ff16d20f0e6ef6bbf77c46e2a

## Related issues
- https://github.com/Podcastindex-org/web-ui/issues/139

## Related PRs (preparation for this one)
- https://github.com/Podcastindex-org/web-ui/pull/141
- https://github.com/Podcastindex-org/web-ui/pull/142

## References
- https://www.kindacode.com/article/react-router-uselocation-hook-tutorial-and-examples/
- https://thewebdev.info/2020/07/26/how-to-use-url-parameters-and-query-strings-with-react-router/
- https://v5.reactrouter.com/web/example/query-parameters
- https://v5.reactrouter.com/web/api/Hooks/usehistory