### PR TITLE
Castamatic App -  better links for elements

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -665,27 +665,27 @@
     "supportedElements": [
       {
         "elementName": "Boostagrams",
-        "elementURL": "https://itunes.apple.com/it/app/castamatic-podcast-player/id966632553?mt=8"
+        "elementURL": "https://itunes.apple.com/us/app/castamatic-podcast-player/id966632553"
       },
       {
         "elementName": "Value",
-        "elementURL": "https://itunes.apple.com/it/app/castamatic-podcast-player/id966632553?mt=8"
+        "elementURL": "https://itunes.apple.com/us/app/castamatic-podcast-player/id966632553"
       },
       {
         "elementName": "Funding",
-        "elementURL": "https://itunes.apple.com/it/app/castamatic-podcast-player/id966632553?mt=8"
+        "elementURL": "https://itunes.apple.com/us/app/castamatic-podcast-player/id966632553"
       },
       {
         "elementName": "Chapters",
-        "elementURL": "https://itunes.apple.com/it/app/castamatic-podcast-player/id966632553?mt=8"
+        "elementURL": "https://castamatic.com/#features"
       },
       {
         "elementName": "Search",
-        "elementURL": "https://itunes.apple.com/it/app/castamatic-podcast-player/id966632553?mt=8"
+        "elementURL": "https://itunes.apple.com/us/app/castamatic-podcast-player/id966632553"
       },
       {
         "elementName": "Sat Streaming",
-        "elementURL": "https://itunes.apple.com/it/app/castamatic-podcast-player/id966632553?mt=8"
+        "elementURL": "https://itunes.apple.com/us/app/castamatic-podcast-player/id966632553"
       }
     ]
   },


### PR DESCRIPTION
Changed most Castamatic feature links from Italian App store page to US App store page.

Chapters are described on homepage #features section, so used that for that element.