### PR TITLE
Add Fountain Person Tag

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -239,6 +239,10 @@
       {
         "elementName": "Chapters",
         "elementURL": "https://twitter.com/fountain_app/status/1438166024478724098"
+      },
+      {
+        "elementName": "Person",
+        "elementURL": "https://twitter.com/fountain_app/status/1504450017146417153"
       }
     ]
   },


### PR DESCRIPTION
Added support for the `<podcast:person>` tag in version 0.3.10 - https://twitter.com/fountain_app/status/1504450017146417153