### PR TITLE
Update Tsacdop and Escapepod

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -787,6 +787,10 @@
       {
         "elementName": "Funding",
         "elementURL": "https://github.com/stonega/tsacdop/releases/tag/v0.5.4"
+      },
+      {
+        "elementName": "Chapters",
+        "elementURL": "https://github.com/stonega/tsacdop/releases/tag/v0.5.8"
       }
     ]
   },
@@ -817,7 +821,7 @@
       "podcast player",
       "open source"
     ],
-    "appUrl": "https://github.com/y20k/escapepod",
+    "appUrl": "https://codeberg.org/y20k/escapepod",
     "appIconUrl": "escapepod.png",
     "platforms": [
       "Android",


### PR DESCRIPTION
**Tsacdop** supports _Chapters_ since [v0.5.8](https://github.com/stonega/tsacdop/releases/tag/v0.5.8)
**Escapepod** switched repository from [GitHub](https://github.com/y20k/escapepod) to [Codeberg](https://codeberg.org/y20k/escapepod)