### PR TITLE
Don't request a WebLN provider for boostagrams if the podcast/episode is not value-enabled

### DIFF
--- a/ui/src/components/Boostagram/index.tsx
+++ b/ui/src/components/Boostagram/index.tsx
@@ -25,12 +25,15 @@ export default class Boostagram extends React.PureComponent<IProps> {
 
     async componentDidMount() {
         try {
-            await requestProvider()
             const { episode, podcast } = this.props
+            const destinations = episode?.value?.destinations || podcast?.value?.destinations
+
+            if (destinations) {
+                await requestProvider()
+            }
+
             this.setState({
-                destinations:
-                    episode?.value?.destinations ||
-                    podcast?.value?.destinations,
+                destinations: destinations,
                 senderName: localStorage.getItem('senderName'),
             })
         } catch (error) {}


### PR DESCRIPTION
The `await requestProvider()` call causes Alby to immediately open a window asking to connect to my wallet. This seems kind of pointless to do for podcasts/episodes that do not use the value tag.

This PR updates the Boostagram code to only make that call for podcasts/episodes that have value recipients.