### PR TITLE
Detect WebLN provider through presence of `window.webln`

### DIFF
--- a/ui/src/components/Boostagram/index.tsx
+++ b/ui/src/components/Boostagram/index.tsx
@@ -24,19 +24,13 @@ export default class Boostagram extends React.PureComponent<IProps> {
     webln: any
 
     async componentDidMount() {
-        try {
-            const { episode, podcast } = this.props
-            const destinations = episode?.value?.destinations || podcast?.value?.destinations
+        const { episode, podcast } = this.props
+        const destinations = episode?.value?.destinations || podcast?.value?.destinations
 
-            if (destinations) {
-                await requestProvider()
-            }
-
-            this.setState({
-                destinations: destinations,
-                senderName: localStorage.getItem('senderName'),
-            })
-        } catch (error) {}
+        this.setState({
+            destinations: destinations,
+            senderName: localStorage.getItem('senderName'),
+        })
     }
 
     handleSatChange = (e: any) => {
@@ -190,6 +184,11 @@ export default class Boostagram extends React.PureComponent<IProps> {
         let boostagram = (
             <div className="boostagram-corner" style={{ display: 'none' }} />
         )
+
+        if ((window as any).webln === undefined) {
+            return boostagram; // WebLN provider not available
+        }
+
         if (this.state.destinations) {
             boostagram = (
                 <div className="boostagram-corner">


### PR DESCRIPTION
Whenever a podcast page with value recipients is opened, it causes the WebLN provider (e.g. Alby) to immediately pop up a window asking for authorization. This is due to the use of `requestProvider()` from the `webln` library to detect whether the user has a WebLN provider installed. This function seems to not only detect the provider but also enables it at the same time (causing the authorization popup): https://github.com/joule-labs/webln/blob/ab22196dfa4675ad682632dc87400f03516cd211/src/client.ts#L26

Another way we could detect the presence of a WebLN provider is just by looking to see if `webln` is defined in the `window` object. This is currently what the `webln` library does and what is recommended by the WebLN Guide.

WebLN library: https://github.com/joule-labs/webln/blob/ab22196dfa4675ad682632dc87400f03516cd211/src/client.ts#L21-L22
WebLN Guide: https://www.webln.guide/building-lightning-apps/getting-started#detecting-webln-support

