### PR TITLE
Added live episodes to the front page

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -112,6 +112,27 @@ app.use('/api/episodes/byfeedid', async (req, res) => {
     res.send(response)
 })
 
+app.use('/api/episodes/live', async (req, res) => {
+    let max = req.query.max
+    const response = await api.custom('episodes/live', {pretty: true, max: max})
+    const minPublished = Math.floor(new Date().getTime() / 1000) - 3600
+
+    // assume live episodes posted within the past hour are live
+    // since the api doesn't provide start and end times
+
+    response.items = response.items.filter(item => {
+        return item.datePublished >= minPublished
+    })
+
+    response.count = response.items.length;
+
+    if (response.count === 0) {
+        response.description = 'No matching items'
+    }
+
+    res.send(response)
+})
+
 app.use('/api/add/byfeedurl', async (req, res) => {
     let feedUrl = req.query.url
     const response = await apiAdd.addByFeedUrl(feedUrl)

--- a/ui/src/components/RecentPodcasts/index.tsx
+++ b/ui/src/components/RecentPodcasts/index.tsx
@@ -11,6 +11,7 @@ import {Link} from "react-router-dom";
 
 interface IProps {
     title?: string
+    liveTitle?: string
     podcasts?: Array<any>
     loading?: boolean
 }
@@ -60,7 +61,7 @@ export default class RecentPodcasts extends React.Component<IProps, IState> {
     }
 
     render() {
-        const {loading, title, podcasts} = this.props
+        const {loading, title, liveTitle, podcasts} = this.props
         const {index} = this.state
         const selectedPodcast = podcasts[index]
         return (
@@ -87,7 +88,7 @@ export default class RecentPodcasts extends React.Component<IProps, IState> {
                         </div>
                         {title && (
                             <div className="player-title">
-                                <b>{title}</b>
+                                <b>{selectedPodcast.live ? liveTitle : title}</b>
                             </div>
                         )}
                         <div className="player-cover-art">

--- a/ui/src/pages/landing.tsx
+++ b/ui/src/pages/landing.tsx
@@ -11,14 +11,14 @@ import './styles.scss'
 interface IProps {}
 interface IState {
     loading?: boolean
-    recentPodcasts?: Array<any>
+    podcasts?: Array<any>
     stats?: {}
 }
 
 export default class Landing extends React.Component<IProps, IState> {
     state = {
         loading: true,
-        recentPodcasts: [],
+        podcasts: [],
         stats: {
             feedCountTotal: '1,318,328',
             feedCount3days: '81,919',
@@ -36,13 +36,13 @@ export default class Landing extends React.Component<IProps, IState> {
 
     async componentDidMount(): Promise<void> {
         this._isMounted = true
-        const recentPodcasts = (await this.getRecentEpisodes()).items
+        const podcasts = await this.getEpisodes()
         const stats = await this.getStats()
 
         if (this._isMounted) {
             this.setState({
                 loading: false,
-                recentPodcasts,
+                podcasts,
                 stats,
             })
         }
@@ -68,8 +68,29 @@ export default class Landing extends React.Component<IProps, IState> {
         return await response.json()
     }
 
+    async getLiveEpisodes() {
+        let response = await fetch(`/api/episodes/live?max=3`, {
+            credentials: 'same-origin',
+            method: 'GET',
+        })
+        return await response.json()
+    }
+
+    async getEpisodes() {
+        let liveResponse = await this.getLiveEpisodes()
+        let episodes = liveResponse.items.map(ep => {
+            ep.live = true
+            return ep
+        })
+
+        let recentResponse = await this.getRecentEpisodes()
+        episodes = episodes.concat(recentResponse.items)
+
+        return episodes;
+    }
+
     render() {
-        const { loading, recentPodcasts, stats } = this.state
+        const { loading, podcasts, stats } = this.state
         updateTitle('Home')
         return (
             <div className="landing-content">
@@ -108,8 +129,9 @@ export default class Landing extends React.Component<IProps, IState> {
                     <div className="hero-pitch-right">
                         <RecentPodcasts
                             title="Recent Podcasts"
+                            liveTitle="⬤ Live Podcasts"
                             loading={loading}
-                            podcasts={recentPodcasts}
+                            podcasts={podcasts}
                         />
                     </div>
                 </div>

--- a/ui/src/pages/landing.tsx
+++ b/ui/src/pages/landing.tsx
@@ -78,7 +78,7 @@ export default class Landing extends React.Component<IProps, IState> {
 
     async getEpisodes() {
         let liveResponse = await this.getLiveEpisodes()
-        let episodes = liveResponse.items.map(ep => {
+        let episodes = liveResponse.map(ep => {
             ep.live = true
             return ep
         })


### PR DESCRIPTION
Shows live episodes posted within the past hour on the front page of the website. Live episodes appear before recent episodes in the carousel and the user can switch between them by clicking on the normal left/right buttons.

![image](https://user-images.githubusercontent.com/16781/199896028-bba74c16-9f6b-4580-96d7-4c0650e72d0b.png)

This code makes the assumption that live episodes posted within the past hour are currently live. The API doesn't currently provide the live status or start and end times of live episodes.