### PR TITLE
Button for copying RSS instead of text

### DIFF
--- a/ui/src/components/PodcastHeader/index.tsx
+++ b/ui/src/components/PodcastHeader/index.tsx
@@ -151,7 +151,7 @@ export default class PodcastHeader extends React.PureComponent<IProps, PodState>
                                 : ""
                             }
                             {feedURL ?
-                                <span onClick={this.copyClicked}>{ this.state.copyMessage }</span>
+                                <button onClick={this.copyClicked}>{ this.state.copyMessage }</button>
                                 : ""
                             }
                         </div>


### PR DESCRIPTION
This commit replaces the the text `<span>` tag by a `<button>` for copying the RSS feed of podcasts.

As a text, it was not so clear that the user could interact with it.