### PR TITLE
Added live episodes to podcast page

### DIFF
--- a/ui/src/components/EpisodeItem/index.tsx
+++ b/ui/src/components/EpisodeItem/index.tsx
@@ -24,6 +24,7 @@ interface IProps {
     description?: string
     datePublished?: number
     hasComments: boolean
+    startTime?: number
     onPlay?: any
     onPause?: any
 }
@@ -91,6 +92,7 @@ export default class EpisodeItem extends React.PureComponent<IProps> {
             description,
             datePublished,
             hasComments,
+            startTime,
         } = this.props
         const episodeLink = link
         const episodeEnclosure = enclosureUrl
@@ -113,9 +115,15 @@ export default class EpisodeItem extends React.PureComponent<IProps> {
                     <div className="episode-info">
                         <div className="episode-title">{title}</div>
                         <p className="episode-date">
-                            <time dateTime={getISODate(datePublished)}>
-                                {getPrettyDate(datePublished)}
-                            </time>
+                            {startTime ? (
+                                <time dateTime={getISODate(startTime)}>
+                                    {getPrettyDate(startTime)}
+                                </time>
+                            ) : (
+                                <time dateTime={getISODate(datePublished)}>
+                                    {getPrettyDate(datePublished)}
+                                </time>
+                            )}
                         </p>
 
                         <div className="episode-links">

--- a/ui/src/components/EpisodeList/index.tsx
+++ b/ui/src/components/EpisodeList/index.tsx
@@ -1,0 +1,112 @@
+import * as React from 'react'
+import EpisodeItem from '../EpisodeItem'
+import InfiniteList from '../InfiniteList'
+import { fixURL } from '../../utils'
+
+const he = require('he')
+
+interface IProps {
+    title: string
+    podcast: any
+    episodes: Array<Object>
+    playingEpisode: Object
+    onEpisodePlay: Function
+    onEpisodePause: Function
+}
+
+export default class EpisodeList extends React.PureComponent<IProps> {
+    state = {
+        index: 0,
+    }
+    episodeItems: any[] = []
+
+    constructor(props) {
+        super(props)
+        this.onEpisodePlay = this.onEpisodePlay.bind(this)
+        this.onEpisodePause = this.onEpisodePause.bind(this)
+        this.renderEpisode = this.renderEpisode.bind(this)
+    }
+
+    async componentDidUpdate(prevProps) {
+        const { episodes, playingEpisode } = this.props
+
+        this.episodeItems.forEach((episodeItem, index) => {
+            episodeItem.current.setPlaying(
+                playingEpisode == episodes[index]
+            )
+        })
+    }
+
+    onEpisodePlay(index: number) {
+        // trigger the callback to play the episode
+        this.props.onEpisodePlay(this.props.episodes[index])
+    }
+
+    onEpisodePause() {
+        // trigger the callback to pause the episode
+        this.props.onEpisodePause()
+    }
+
+    renderEpisode(item, index: number) {
+        let {
+            id,
+            title,
+            image,
+            feedImage,
+            link,
+            enclosureUrl,
+            transcriptUrl,
+            description,
+            datePublished,
+            value,
+            socialInteract,
+            startTime
+        } = item
+        let {podcast} = this.props
+        // try to use episode image, fall back to feed images
+        image = image || feedImage || podcast.image || podcast.artwork
+        enclosureUrl = fixURL(enclosureUrl)
+        description = he.decode(description)
+
+        // create a reference to the generated EpisodeItem if one doesn't already exist
+        if (index >= this.episodeItems.length) {
+            this.episodeItems.push(React.createRef<EpisodeItem>())
+        }
+
+        return (
+            <div key={index}>
+                <EpisodeItem
+                    ref={this.episodeItems[index]}
+                    id={id}
+                    index={index}
+                    title={title}
+                    image={image}
+                    link={link}
+                    value={value}
+                    enclosureUrl={enclosureUrl}
+                    transcriptUrl={transcriptUrl}
+                    description={description}
+                    datePublished={datePublished}
+                    hasComments={socialInteract && socialInteract.length > 0}
+                    startTime={startTime}
+                    onPlay={this.onEpisodePlay}
+                    onPause={this.onEpisodePause}
+                />
+            </div>
+        )
+    }
+
+    render() {
+        const { title, episodes } = this.props
+
+        return (
+            <div className="episodes-list">
+                <h2 className="episode-header">{title}</h2>
+                <InfiniteList
+                    data={episodes}
+                    itemRenderer={this.renderEpisode}
+                />
+            </div>
+        )
+    }
+}


### PR DESCRIPTION
Uses the `liveItems` data returned by the API to show currently live episodes under a new "Live Now!" section on the podcast page.

This adds a new `EpisodeList` component to show the live and normal episodes as two separate lists on the page. This required some refactoring of code that passed indexes into the episodes array to instead pass episode objects.

This also adds a new `playingEpisode` property to track the currently playing episode and signal the EpisodeLists to update their play/pause buttons accordingly.

Here's a screenshot of what it looks like:

![image](https://user-images.githubusercontent.com/16781/227102906-864a26c2-4833-4344-a946-c47ab7f5d6fd.png)
