### PR TITLE
Fix #244: Disable buffer for comments

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -137,6 +137,10 @@ app.use('/api/comments/byepisodeid', async (req, res) => {
     const cache = new InMemoryCache();
     const fetcher = makeRateLimitedFetcher(fetch);
 
+    // Disable buffering in the nginx server so that the delivery of
+    // chunks are not delayed
+    res.setHeader('X-Accel-Buffering', 'no');
+
     const sentCommenters = {};
 
     const threadcap = await makeThreadcap(socialInteract[0].uri, { userAgent, cache, fetcher });


### PR DESCRIPTION
Comments for an episode are sent back to the front end using chunked Transfer Enconding, but that that is not supported on HTTP/2 which is used by the reverse proxy (nginx).

At the moment nginx buffers the chunks before sending them to the browser, which breaks the way the chunks are processed.

With this commit, we use the header `X-Accel-Buffering` to disable this buffering, which worked in local testing.

We should still add a more clear chunk delimiter so that any other buffering or unknown edge case will not
break the comments function (increase robustness).

Co-authored-by: @ericpp

Fixes #244