### PR TITLE
Refactoring #244 - Comments robustness

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -178,7 +178,7 @@ function writeThreadcapChunk(processedNodeId, threadcap, sentCommenters, res) {
         threadcapChunk.commenters[comment.attributedTo] = threadcap.commenters[comment.attributedTo];
     }
 
-    res.write(JSON.stringify(threadcapChunk))
+    res.write(JSON.stringify(threadcapChunk) + '\n')
 }
 
 // ------------------------------------------------


### PR DESCRIPTION
This commit is a refactoring on the Comments function to improve robustness for loading partial responses form the comments API.

Once we introduced partial responses (i.e. chunked encoding), it worked in dev, but failed in production due to buffering in the reverse proxy (nginx).

This was already solved with
https://github.com/Podcastindex-org/web-ui/pull/247, but only if the reverse proxy remains unchanged.

With this refactoring, the implementation would continue to work even if buffering took place, making it more robust.

For testing, the change introduced in the PR mentioned above was reverted (temporarily).

For additinal testing instructions, see
https://github.com/Podcastindex-org/web-ui/pull/247#issuecomment-1507633512