### PR TITLE
Remove inaccurate stats during load

### DIFF
--- a/ui/src/pages/landing.tsx
+++ b/ui/src/pages/landing.tsx
@@ -20,12 +20,12 @@ export default class Landing extends React.Component<IProps, IState> {
         loading: true,
         recentPodcasts: [],
         stats: {
-            feedCountTotal: '1,318,328',
-            feedCount3days: '81,919',
-            feedCount10days: '208,264',
-            feedCount30days: '303,007',
-            feedCount60days: '376,576',
-            feedCount90days: '607,991',
+            feedCountTotal: '-,---,---',
+            feedCount3days: '--,---',
+            feedCount10days: '---,---',
+            feedCount30days: '---,---',
+            feedCount60days: '---,---',
+            feedCount90days: '---,---',
         },
     }
     _isMounted = false


### PR DESCRIPTION
This is a small change to replace the placeholder stats with dashes.

These stats are only seen by people with JavaScript on, and only while they wait for the API to populate the correct stats in their place. By replacing these numbers with dashes, it will a) avoid any content shift; b) avoid idiots like me reading the old figures and wondering what's happened to the index.