### PR TITLE
Change 'MacOS' to 'macOS' to match other apps

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -2387,7 +2387,7 @@
     "platforms": [
       "Android",
       "iOS",
-      "MacOS",
+      "macOS",
       "Web",
       "Windows"
     ],


### PR DESCRIPTION
Fixes failing action