### PR TITLE
Remove open

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -7,14 +7,14 @@
         <!-- <link href="https://unpkg.com/normalize.css@^7.0.0" rel="stylesheet" /> -->
         <title>Podcastindex.org</title>
         <meta name="title" content="Podcastindex.org">
-        <meta name="description" content="The Podcast Index is here to preserve, protect and extend the open, independent podcasting ecosystem.">
+        <meta name="description" content="The Podcast Index is here to preserve, protect and extend the podcasting ecosystem.">
         <meta property="og:type" content="website">
         <meta property="og:url" content="https://podcastindex.org/">
         <meta property="og:title" content="Podcastindex.org">
-        <meta property="og:description" content="The Podcast Index is here to preserve, protect and extend the open, independent podcasting ecosystem.">
+        <meta property="og:description" content="The Podcast Index is here to preserve, protect and extend the podcasting ecosystem.">
         <meta property="twitter:url" content="https://podcastindex.org/">
         <meta property="twitter:title" content="Podcastindex.org">
-        <meta property="twitter:description" content="The Podcast Index is here to preserve, protect and extend the open, independent podcasting ecosystem.">
+        <meta property="twitter:description" content="The Podcast Index is here to preserve, protect and extend the podcasting ecosystem.">
     </head>
 
     <body>
@@ -33,7 +33,7 @@
 
                 <h2>Let's preserve podcasting as a platform for free speech</h2>
 
-                <p>We do this by enabling developers to have access to an open, categorized index that will always be available for free, for any use.</p>
+                <p>We do this by enabling developers to have access to an index that will always be available for free, for any use.</p>
 
                 <p>
                     Listen to the

--- a/ui/src/pages/landing.tsx
+++ b/ui/src/pages/landing.tsx
@@ -76,14 +76,12 @@ export default class Landing extends React.Component<IProps, IState> {
                 <div className="hero-pitch">
                     <div className="hero-pitch-left">
                         <h1 className="hero-pitch-text">
-                            The Podcast Index is here to preserve, protect and extend the open,
-                            independent podcasting ecosystem.
+                            The Podcast Index is here to preserve, protect and extend the podcasting ecosystem.
                         </h1>
 
                         <div className="hero-pitch-subtitle">
                             We do this by enabling developers to have access to
-                            an open, categorized index that will always be
-                            available for free, for any use.
+                            an index that will always be available for free, for any use.
                         </div>
                         <div className="hero-pitch-subtitle">
                             Try a <Link to="/apps"><u>new podcast app</u></Link> today and see how much better the experience can be.
@@ -149,7 +147,7 @@ export default class Landing extends React.Component<IProps, IState> {
                         API services of value to developers and organizations.
                     </p>
                     <h3>Mission and Goal</h3>
-                    <p>Preserve, protect and extend the open, independent podcasting ecosystem.</p>
+                    <p>Preserve, protect and extend the podcasting ecosystem.</p>
                     <p>
                         Re-tool podcasting to a platform of value exchange that
                         includes developers with podcasters and listeners.


### PR DESCRIPTION
Remove "open podcasting" after Adam's comment on episode 132.

Note: this is mostly a joke but can be merged if Dave and Adam agree.