### PR TITLE
added new P2.0 features, modified platforms list

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -416,7 +416,7 @@
     "appIconUrl": "podcastguru.jpg",
     "platforms": [
       "Android",
-      "MacOS",
+      "macOS",
       "iOS"
     ],
     "supportedElements": [

--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -416,13 +416,25 @@
     "appIconUrl": "podcastguru.jpg",
     "platforms": [
       "Android",
-      "Web",
+      "MacOS",
       "iOS"
     ],
     "supportedElements": [
       {
         "elementName": "Search",
         "elementURL": "https://twitter.com/podcastguru_app/status/1325834426346041347"
+      },
+      {
+        "elementName": "Boostagrams",
+        "elementURL": "https://twitter.com/podcastguru_app/status/1655685430761619459?s=20"
+      },
+      {
+        "elementName": "Live",
+        "elementURL": "https://twitter.com/podcastguru_app/status/1655685430761619459?s=20"
+      },
+      {
+        "elementName": "Value",
+        "elementURL": "https://twitter.com/podcastguru_app/status/1655685430761619459?s=20"
       },
       {
         "elementName": "Transcript",


### PR DESCRIPTION
Added MacOS as a supported platform in-addition to iOS.  Since our app is -truly- native it will run on a Macbook with an M1 or M2 chipset and can be installed through the app store.