### PR TITLE
Adjusted top bar button hover to be more noticable

### DIFF
--- a/ui/src/components/Button/styles.scss
+++ b/ui/src/components/Button/styles.scss
@@ -1,6 +1,6 @@
 :root {
-    --button-background: #F0F0F0;
-    --button-hover-color: #f2f2f2;
+    --button-background: #f7f7f7;
+    --button-hover-color: #ededed;
 
     &[data-theme="dark"] {
         --button-background: #1a1a1a;


### PR DESCRIPTION
I've adjusted the top bar buttons in light mode to be more noticeable when you hover over them:

Here's what hovering over the Apps button currently looks like:
![image](https://github.com/Podcastindex-org/web-ui/assets/16781/3bc32d55-a3d8-4a09-893d-97c3fe72f595)

And here is what it looks like with this change:
![image](https://github.com/Podcastindex-org/web-ui/assets/16781/b2ef3016-d84e-4051-a8a8-851fc6219193)