### PR TITLE
Add Fediverse platform to Peertube and CastGarden

### DIFF
--- a/server/data/apps-schema.json
+++ b/server/data/apps-schema.json
@@ -78,7 +78,8 @@
               "Start9",
               "Citadel",
               "Hive",
-              "Discord"
+              "Discord",
+              "Fediverse"
             ]
           }
         },

--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -2556,6 +2556,7 @@
     "appUrl": "https://joinpeertube.org",
     "appIconUrl": "peertube.png",
     "platforms": [
+      "Fediverse",
       "Web"
     ],
     "supportedElements": [
@@ -2738,6 +2739,7 @@
     "appUrl": "https://cast.garden",
     "appIconUrl": "castgarden.png",
     "platforms": [
+      "Fediverse",
       "Hive",
       "Mobile",
       "Web"


### PR DESCRIPTION
As asked in #287 .

Podverse and apps with `socialInteract` and `ActivityPub` support can be added later if someones see it's fit.