### PR TITLE
Fix v4v total

### DIFF
--- a/ui/src/pages/Podcast/Value4Value/index.tsx
+++ b/ui/src/pages/Podcast/Value4Value/index.tsx
@@ -100,7 +100,7 @@ export default class Value4Value extends React.PureComponent<IProps> {
             if (status !== "true" || startAt === undefined || !this._isMounted) {
                 break
             }
-            grandTotal += total
+            grandTotal = total // total reports the total for all feeds
 
             feeds.forEach((value) => {
                 allPages.push(value)


### PR DESCRIPTION
The total v4v feeds was adding the total every request instead of using the value reported.