### PR TITLE
Fix attempting to select undefined episode

### DIFF
--- a/ui/src/components/EpisodesPlayer/index.tsx
+++ b/ui/src/components/EpisodesPlayer/index.tsx
@@ -97,7 +97,7 @@ export default class EpisodesPlayer extends React.PureComponent<IProps> {
                 selectedEpisodeIsLive: liveEpisode
             },
             () => {
-                if (onSelectedEpisodeChange) {
+                if (onSelectedEpisodeChange && newSelectedEpisode !== undefined) {
                     onSelectedEpisodeChange(newSelectedEpisode.id)
                 }
             })


### PR DESCRIPTION
Happens when there is no episodes in the index

Resolves issue raised in https://podcastindex.social/@kevinb66/110916954812227755 with https://podcastindex.org/podcast/6578610

Can also see with https://podcastindex.org/podcast/522613