### PR TITLE
Correct Podcast Republic in apps.json

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -533,8 +533,8 @@
     ],
     "supportedElements": [
       {
-        "elementName": "Transcript",
-        "elementURL": "https://twitter.com/castrepublic/status/1477881117789196289"
+        "elementName": "Chapters",
+        "elementURL": "https://twitter.com/castrepublic/status/1511853002097065984"
       }
     ]
   },


### PR DESCRIPTION
The linked tweet refers to the Funding tag being implemented, rather than Transcript support. I couldn't find any indication of support for the Funding tag.