### PR TITLE
Add podroll to the schema and to podnews directory

### DIFF
--- a/server/data/apps-schema.json
+++ b/server/data/apps-schema.json
@@ -131,7 +131,8 @@
             "Images",
             "License",
             "Txt",
-            "Wallet Switching"
+            "Wallet Switching",
+            "Podroll"
           ]
         },
         "elementURL": {

--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -1144,6 +1144,10 @@
         "elementURL": "https://podnews.net/podcast"
       },
       {
+        "elementName": "Podroll",
+        "elementURL": "https://podnews.net/podcast"
+      },
+      {
         "elementName": "Search",
         "elementURL": "https://podnews.net"
       }


### PR DESCRIPTION
Following P20 152 I added podroll to my feed, but the only "platform" that I've found that implement this tags is podnews directory.

@jamescridland can you confirm that's correct? Also I see "listen" and "directory" in the list, but I don't know if the listen section still applies.


Related alto to https://github.com/Podcastindex-org/web-ui/issues/288