### PR TITLE
Podfriend web also suppports podroll

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -199,6 +199,10 @@
       {
         "elementName": "Social Interact",
         "elementURL": "https://twitter.com/PodcastindexOrg/status/1497630426457911304"
+      },
+      {
+        "elementName": "Podroll",
+        "elementURL": "https://www.podfriend.com/"
       }
     ]
   },


### PR DESCRIPTION
What I'm not sure if the open source tag still applies, does the code was moved to another repo?

https://github.com/MartinMouritzen/Podfriend has no activity in 2 years.

CC @MartinMouritzen 