### PR TITLE
Podroll, Update frequency and Block tags for Blubrry & PowerPress

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -1260,6 +1260,18 @@
       {
         "elementName": "Medium",
         "elementURL": "https://blubrry.com/support/media-hosting-documentation/blubrry-dashboard-podcasting-2-0-features/"
+      },
+      {
+        "elementName": "Update Frequency",
+        "elementURL": "https://blubrry.com/support/media-hosting-documentation/blubrry-dashboard-podcasting-2-0-features/"
+      },
+      {
+        "elementName": "Podroll",
+        "elementURL": "https://blubrry.com/support/media-hosting-documentation/blubrry-dashboard-podcasting-2-0-features/"
+      },
+      {
+        "elementName": "Block",
+        "elementURL": "https://blubrry.com/support/media-hosting-documentation/blubrry-dashboard-podcasting-2-0-features/"
       }
     ]
   },
@@ -1347,6 +1359,18 @@
       },
       {
         "elementName": "Medium",
+        "elementURL": "https://blubrry.com/support/powerpress-documentation/powerpress-podcasting-2-0-features/"
+      },
+      {
+        "elementName": "Update Frequency",
+        "elementURL": "https://blubrry.com/support/powerpress-documentation/powerpress-podcasting-2-0-features/"
+      },
+      {
+        "elementName": "Podroll",
+        "elementURL": "https://blubrry.com/support/powerpress-documentation/powerpress-podcasting-2-0-features/"
+      },
+      {
+        "elementName": "Block",
         "elementURL": "https://blubrry.com/support/powerpress-documentation/powerpress-podcasting-2-0-features/"
       }
     ]


### PR DESCRIPTION
Added Podroll, Update frequency and Block tags support for Blubrry and PowerPress. We also added support for Remote Item but I didn't see a define for it in apps-schema.json so I didn't add that one yet. Do we need to add an element for remote item to apps-schema.json? 