### PR TITLE
Zion - no longer Linux & open source?

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -1066,8 +1066,7 @@
       "iOS",
       "Android",
       "macOS",
-      "Windows",
-      "Linux"
+      "Windows"
     ],
     "supportedElements": [
       {

--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -1054,32 +1054,6 @@
     ]
   },
   {
-    "appName": "Zion",
-    "appType": [
-      "app",
-      "open source"
-    ],
-    "appUrl": "https://getzion.com",
-    "appIconUrl": "n2n2.png",
-    "platforms": [
-      "Mobile",
-      "iOS",
-      "Android",
-      "macOS",
-      "Windows"
-    ],
-    "supportedElements": [
-      {
-        "elementName": "Value",
-        "elementURL": "https://getzion.com"
-      },
-      {
-        "elementName": "Search",
-        "elementURL": "https://getzion.com"
-      }
-    ]
-  },
-  {
     "appName": "gpodder",
     "appType": [
       "app",


### PR DESCRIPTION
The link to the project is broken or it's no longer open source and no longer available on Linux

It could be that the link is just wrong, or the linux is available under different name on some different page, but at least I can't figure out that from the link, might be that this project is already dead (no longer a podcast player)