### PR TITLE
Added windows platform to Kasts

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -1093,7 +1093,8 @@
     "platforms": [
       "Linux",
       "Mobile",
-      "Android"
+      "Android",
+      "Windows"
     ],
     "supportedElements": [
       {


### PR DESCRIPTION
Kasts has a windows version that is linked at the bottom of the [current website](https://apps.kde.org/kasts/) and also has a stable/nightly version linked in the [source code page](https://invent.kde.org/multimedia/kasts)