### PR TITLE
Add Fediverse platform to PI

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -1502,6 +1502,7 @@
     "appUrl": "https://podcastindex.org",
     "appIconUrl": "podcastindex.jpg",
     "platforms": [
+      "Fediverse",
       "Web"
     ],
     "supportedElements": [


### PR DESCRIPTION
I would argue that the "comments" button and the AP Bridge entitle the PI entry to have the Fediverse platform listed.