### PR TITLE
Sovereign Feeds supports Alt Enclosures

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -3379,6 +3379,10 @@
     ],
     "supportedElements": [
       {
+        "elementName": "Alternate Enclosure",
+        "elementURL": "https://sovereignfeeds.com"
+      },
+      {
         "elementName": "Block",
         "elementURL": "https://sovereignfeeds.com"
       },


### PR DESCRIPTION
![imagen](https://github.com/user-attachments/assets/ae7688ba-6af9-4d44-87c1-1b5ea4479fa4)
