### PR TITLE
myWebLog Self-hosted

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -2538,7 +2538,8 @@
     "appType": [
       "hosting",
       "website",
-      "open source"
+      "open source",
+      "self-hosted"
     ],
     "appUrl": "https://bitbadger.solutions/open-source/myweblog",
     "appIconUrl": "myweblog.png",


### PR DESCRIPTION
There are multiple hostings providers listed that act as a SaaS and also can be used self-hosted, I don't know I those also should have added the self-hosted attribute.

But myweblog doesn't seems to have a SaaS, so it seems appropriate.