### PR TITLE
Update link to podcastindex.social

### DIFF
--- a/ui/src/pages/landing.tsx
+++ b/ui/src/pages/landing.tsx
@@ -186,7 +186,7 @@ export default class Landing extends React.Component<IProps, IState> {
                             X - @podcastindexorg
                         </a>
                         {' '} or{' '}
-                        <a href="https://podcastindex.social/">
+                        <a href="https://podcastindex.social/public/local/">
                             our Mastodon server
                         </a>
                         .


### PR DESCRIPTION
podcastindex.social redirects to -> https://podcastindex.social/explore with shows toots from random (different intances) accounts.

I think the local timeline is a better option. That or https://podcastindex.social/directory