### PR TITLE
List funding tag support for Pocket Casts

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -87,6 +87,9 @@
       {
         "elementName": "Transcript",
         "elementURL": "https://support.pocketcasts.com/knowledge-base/episode-transcripts/"
+      },
+      {
+        "elementName": "Funding"
       }
     ]
   },


### PR DESCRIPTION
I’m not sure if you can update info apps that aren’t yours, but I thought I would see. Pocket Casts has publicly released support for the funding tag (at least on iOS/iPadOS).