### PR TITLE
feat(schema): add "rss proxy" to appType enum

### DIFF
--- a/server/data/apps-schema.json
+++ b/server/data/apps-schema.json
@@ -42,6 +42,7 @@
               "open source",
               "other",
               "chat bot",
+              "rss proxy",
 	          "self-hosted"
             ]
           }


### PR DESCRIPTION
Added a new "rss proxy" type to the appType enum to support tools that proxy or enhance RSS feeds.