### PR TITLE
Fix and remove broken links or dead apps

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -1783,27 +1783,27 @@
     "supportedElements": [
       {
         "elementName": "Locked",
-        "elementURL": "https://twitter.com/transistorfm"
+        "elementURL": "https://transistor.fm/changelog/podcast-lock"
       },
       {
         "elementName": "Funding",
-        "elementURL": "https://twitter.com/transistorfm"
+        "elementURL": "https://transistor.fm/changelog/"
       },
       {
         "elementName": "Podping",
-        "elementURL": "https://twitter.com/transistorfm"
+        "elementURL": "https://transistor.fm/changelog/"
       },
       {
         "elementName": "Transcript",
-        "elementURL": "https://twitter.com/transistorfm"
+        "elementURL": "https://transistor.fm/changelog/transcripts/"
       },
       {
         "elementName": "Chapters",
-        "elementURL": "https://twitter.com/transistorfm"
+        "elementURL": "https://transistor.fm/changelog/chapters-in-episodes/"
       },
       {
         "elementName": "Person",
-        "elementURL": "https://twitter.com/TransistorFM/status/1575920428068937728"
+        "elementURL": "https://transistor.fm/changelog/people/"
       },
       {
         "elementName": "OP3",


### PR DESCRIPTION
Clean most of apps that no longer exist. Fix some links.

Plus there are some that still work but with broken info on PI apps list.

##
cooler.fm
Website it's down but still on iOS store.
https://downforeveryoneorjustme.com/cooler.fm?proto=https
CC @smoothfm @aj-cooler