### PR TITLE
Enable dependabot for workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"              # Looks for workflow files under .github/
+    schedule:
+      interval: "weekly"        # Check for updates to GitHub Actions every week
+#      day: "sunday"
+#      timezone: "UTC"
+#    groups:
+#      all-actions:
+#        patterns: [ "*" ]
+#    open-pull-requests-limit: 5
+#    commit-message:
+#      prefix: "actions"
+#    labels:
+#      - "dependencies"
+#      - "github-actions"


### PR DESCRIPTION
Create dependabot.yml

Optionally could be enabled for security dependecies: 

- Like on my fork: https://github.com/Marzal/web-ui/network/dependencies
- Going here: https://github.com/Podcastindex-org/web-ui/network/dependencies