### PR TITLE
Improve link Checker

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -23,11 +23,12 @@ jobs:
             --exclude-path _old --no-progress
             --exclude-all-private
             --base-url https://podcastindex.org
+            --remap 'https://developer.mozilla.org/docs/Web/HTTP/Guides/CORS https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS'
+            --include-verbatim --include-wikilinks --include-fragments
             './**/*.md' './**/*.html' './**/*.json' # './**/*.tsx'
 
 #            --accept '100..=103,200..=299'
 #            --root-dir "$(pwd)"
-#            --include-verbatim --include-wikilinks --include-fragments
 #            --suggest      # Suggest link replacements for broken links, using a web archive
 #            --user-agent "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0"
 # https://lychee.cli.rs/guides/cli/


### PR DESCRIPTION
remap Mmdn to en-US to avoid redirect warning
Activate more checks now that all the others are fixed

This PR should NOT trigger the JSON Checker