### PR TITLE
The big cleanse of redundant links

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -2848,13 +2848,13 @@
     "platforms": ["Web", "Mobile"],
     "supportedElements": [
       {
-        "elementName": "Boostagrams",
+        "elementName": "Boostagrams"
       },
       {
-        "elementName": "Chapters",
+        "elementName": "Chapters"
       },
       {
-        "elementName": "Episode",
+        "elementName": "Episode"
       },
       {
         "elementName": "GUID"


### PR DESCRIPTION
Having the same link 12 times it's not helpful, and it's an accessibility nightmare.

Preserved links that showcase the tag/feature, changelogs, articles, FAQs, announces or something minimally relative to the tag.

**TODO:** make the tags change color, underscore or some king of mark to show that there it's a link without having to use the mouse.