### PR TITLE
Add Proof of Work requirement around API endpoints

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -10,3 +10,5 @@ API_USER_AGENT=PodcastIndexBot/@podcast@noagendasocial.com
 PORT=5001
 # this can be 'development' or 'production'
 NODE_ENV=development
+# proof of work difficulty for api endpoints
+POW_DIFFICULTY=3

--- a/server/middleware/index.js
+++ b/server/middleware/index.js
@@ -1,0 +1,47 @@
+const crypto = require('crypto');
+
+function createPowMiddleware(options = {}) {
+  const { difficulty = 3 } = options;
+
+  return (req, res, next) => {
+    if (difficulty === 0) {
+      return next(); // POW is disabled
+    }
+
+    const {
+      'x-pow-nonce': nonce,
+      'x-pow-hash': hash,
+      'x-pow-timestamp': timestamp
+    } = req.headers;
+
+    if (!nonce || !hash || !timestamp) {
+      return res.status(401).json({ error: 'Missing POW headers' });
+    }
+
+    // Verify timestamp is within 5 minutes
+    const now = Math.floor(Date.now() / 1000);
+    const timestampNum = parseInt(timestamp);
+    if (isNaN(timestampNum) || Math.abs(now - timestampNum) > 300) {
+      return res.status(401).json({ error: 'Timestamp expired or invalid' });
+    }
+
+    // Verify hash starts with the correct number of zeros (difficulty level)
+    if (!hash.startsWith('0'.repeat(difficulty))) {
+      return res.status(401).json({ error: 'Hash does not match difficulty level' });
+    }
+
+    // Build and verify challenge
+    const challenge = `${req.method.toUpperCase()}|${req.originalUrl}|${timestamp}`;
+    const challengeHash = crypto.createHash('sha256').update(challenge).digest('hex');
+    const computed = crypto.createHash('sha256').update(challengeHash + nonce).digest('hex');
+
+    if (computed !== hash) {
+      return res.status(401).json({ error: 'Invalid proof of work' });
+    }
+
+    req.powVerified = true;
+    next();
+  }
+}
+
+module.exports = { createPowMiddleware };

--- a/ui/src/components/CommentMenu/index.tsx
+++ b/ui/src/components/CommentMenu/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { authenticatedFetch } from '../../utils/auth'
 
 import './styles.scss'
 
@@ -80,7 +81,7 @@ class CommentMenu extends React.PureComponent<ICommentMenuProps, ICommentMenuSta
         let remoteInteractUrlPattern = localStorage.getItem('commentsRemoteInteractUrlPattern');
 
         if(!remoteInteractUrlPattern) {
-            const response = await fetch('/api/comments/remoteInteractUrlPattern?' + new URLSearchParams({
+            const response = await authenticatedFetch('/api/comments/remoteInteractUrlPattern?' + new URLSearchParams({
                 interactorAccount: interactorAccount
             }));
 

--- a/ui/src/components/Comments/index.tsx
+++ b/ui/src/components/Comments/index.tsx
@@ -4,6 +4,7 @@ import Button from '../Button'
 
 import './styles.scss'
 import CommentMenu from '../CommentMenu'
+import { authenticatedFetch } from '../../utils/auth'
 
 interface IProps {
     id: number,
@@ -176,7 +177,7 @@ export default class Comments extends React.PureComponent<IProps, IState> {
                 loadingComments: true
             });
 
-            const response = await fetch('/api/comments/byepisodeid?' + new URLSearchParams({id: String(this.props.id) }));
+            const response = await authenticatedFetch('/api/comments/byepisodeid?' + new URLSearchParams({id: String(this.props.id) }));
 
             const reader = response.body.getReader();
 

--- a/ui/src/pages/AddFeed/index.tsx
+++ b/ui/src/pages/AddFeed/index.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom'
 import Button from "../../components/Button"
 import ResultItem from "../../components/ResultItem"
 import { cleanSearchQuery, getImage, updateTitle } from '../../utils'
+import { authenticatedFetch } from '../../utils/auth'
 
 import './styles.scss'
 
@@ -104,7 +105,7 @@ export default class AddFeed extends React.PureComponent<IProps> {
     async addFeed(feed: string) {
         let result = null
         // noinspection SpellCheckingInspection
-        await fetch(`/api/add/byfeedurl?url=${feed}`, {
+        await authenticatedFetch(`/api/add/byfeedurl?url=${feed}`, {
             method: 'GET',
         })
             .then(res => res.text())
@@ -121,7 +122,7 @@ export default class AddFeed extends React.PureComponent<IProps> {
     async getPodcastInfo(feed: string) {
         let result = null
         // noinspection SpellCheckingInspection
-        await fetch(`/api/podcasts/byfeedurl?url=${feed}`, {
+        await authenticatedFetch(`/api/podcasts/byfeedurl?url=${feed}`, {
             method: 'GET',
         })
             .then(res => res.text())

--- a/ui/src/pages/Apps/AppsWebPart/index.tsx
+++ b/ui/src/pages/Apps/AppsWebPart/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import SingleApp from './SingleApp'
 import FilterTags from './FilterTags'
+import { authenticatedFetch } from '../../../utils/auth'
 
 import './styles.scss'
 

--- a/ui/src/pages/Podcast/PodcastInfo/index.tsx
+++ b/ui/src/pages/Podcast/PodcastInfo/index.tsx
@@ -4,6 +4,7 @@ import ReactLoading from 'react-loading'
 import EpisodesPlayer from "../../../components/EpisodesPlayer";
 import PodcastHeader from '../../../components/PodcastHeader'
 import { cleanSearchQuery, fixURL, getImage, updateTitle } from '../../../utils'
+import { authenticatedFetch } from '../../../utils/auth'
 import './styles.scss'
 
 interface IProps {
@@ -132,7 +133,7 @@ export default class PodcastInfo extends React.PureComponent<IProps> {
 
     async getPodcastInfo(id: string) {
         // noinspection SpellCheckingInspection
-        let response = await fetch(`/api/podcasts/byfeedid?id=${id}`, {
+        let response = await authenticatedFetch(`/api/podcasts/byfeedid?id=${id}`, {
             // credentials: 'same-origin',
             method: 'GET',
         })
@@ -141,7 +142,7 @@ export default class PodcastInfo extends React.PureComponent<IProps> {
 
     async getPodcastInfoGuid(guid: string) {
         // noinspection SpellCheckingInspection
-        let response = await fetch(`/api/podcasts/byguid?guid=${guid}`, {
+        let response = await authenticatedFetch(`/api/podcasts/byguid?guid=${guid}`, {
             // credentials: 'same-origin',
             method: 'GET',
         })
@@ -150,7 +151,7 @@ export default class PodcastInfo extends React.PureComponent<IProps> {
 
     async getEpisodes(id: string, max: number = 1000) {
         // noinspection SpellCheckingInspection
-        let response = await fetch(`/api/episodes/byfeedid?id=${id}&max=${max}`, {
+        let response = await authenticatedFetch(`/api/episodes/byfeedid?id=${id}&max=${max}`, {
             // credentials: 'same-origin',
             method: 'GET',
         })

--- a/ui/src/pages/Podcast/Value4Value/index.tsx
+++ b/ui/src/pages/Podcast/Value4Value/index.tsx
@@ -6,6 +6,7 @@ import InfiniteList from "../../../components/InfiniteList";
 import ResultItem from '../../../components/ResultItem'
 
 import { getImage, updateTitle } from '../../../utils'
+import { authenticatedFetch } from '../../../utils/auth'
 
 import './styles.scss'
 
@@ -231,7 +232,7 @@ export default class Value4Value extends React.PureComponent<IProps> {
 
     async getValue4ValuePodcasts(max: number) {
         // noinspection SpellCheckingInspection
-        let response = await fetch(`/api/podcasts/bytag?podcast-value&max=${max}`, {
+        let response = await authenticatedFetch(`/api/podcasts/bytag?podcast-value&max=${max}`, {
             // credentials: 'same-origin',
             method: 'GET',
         })
@@ -240,7 +241,7 @@ export default class Value4Value extends React.PureComponent<IProps> {
 
     async getValue4ValuePodcastsPaginated(startAt: number, max: number) {
         // noinspection SpellCheckingInspection
-        let response = await fetch(`/api/podcasts/bytag?podcast-value&max=${max}&start_at=${startAt}`, {
+        let response = await authenticatedFetch(`/api/podcasts/bytag?podcast-value&max=${max}&start_at=${startAt}`, {
             // credentials: 'same-origin',
             method: 'GET',
         })

--- a/ui/src/pages/Search/index.tsx
+++ b/ui/src/pages/Search/index.tsx
@@ -5,6 +5,7 @@ import ResultsEpisodes from "../../components/ResultsEpisodes";
 import ResultsFeeds from "../../components/ResultsFeeds";
 
 import { cleanSearchQuery, encodeSearch, isValidURL, titleizeString, updateTitle } from '../../utils'
+import { authenticatedFetch } from '../../utils/auth'
 
 import './styles.scss'
 
@@ -116,7 +117,7 @@ export default class Results extends React.PureComponent<IProps> {
     async getFeedById(query: string) {
         query = encodeSearch(query)
         // noinspection SpellCheckingInspection
-        let response = await fetch(`/api/podcasts/byfeedid?id=${query}`, {
+        let response = await authenticatedFetch(`/api/podcasts/byfeedid?id=${query}`, {
             // credentials: 'same-origin',
             method: 'GET',
         })
@@ -125,7 +126,7 @@ export default class Results extends React.PureComponent<IProps> {
 
     async getPodcastInfoGuid(guid: string) {
         // noinspection SpellCheckingInspection
-        let response = await fetch(`/api/podcasts/byguid?guid=${guid}`, {
+        let response = await authenticatedFetch(`/api/podcasts/byguid?guid=${guid}`, {
             // credentials: 'same-origin',
             method: 'GET',
         })
@@ -136,7 +137,7 @@ export default class Results extends React.PureComponent<IProps> {
         query = encodeSearch(query)
         const similarParam = similar ? "&similar" : ""
         // noinspection SpellCheckingInspection
-        let response = await fetch(`/api/search/byterm?q=${query}${similarParam}`, {
+        let response = await authenticatedFetch(`/api/search/byterm?q=${query}${similarParam}`, {
             // credentials: 'same-origin',
             method: 'GET',
         })
@@ -146,7 +147,7 @@ export default class Results extends React.PureComponent<IProps> {
     async getTitleSearchResults(query: string) {
         query = encodeSearch(query)
         // noinspection SpellCheckingInspection
-        let response = await fetch(`/api/search/bytitle?q=${query}`, {
+        let response = await authenticatedFetch(`/api/search/bytitle?q=${query}`, {
             // credentials: 'same-origin',
             method: 'GET',
         })
@@ -156,7 +157,7 @@ export default class Results extends React.PureComponent<IProps> {
     async getMusicTermSearchResults(query: string) {
         query = encodeSearch(query)
         // noinspection SpellCheckingInspection
-        let response = await fetch(`/api/search/music/byterm?q=${query}`, {
+        let response = await authenticatedFetch(`/api/search/music/byterm?q=${query}`, {
             // credentials: 'same-origin',
             method: 'GET',
         })
@@ -166,7 +167,7 @@ export default class Results extends React.PureComponent<IProps> {
     async getPersonSearchResults(query: string) {
         query = encodeSearch(query)
         // noinspection SpellCheckingInspection
-        let response = await fetch(`/api/search/byperson?q=${query}&max=1000`, {
+        let response = await authenticatedFetch(`/api/search/byperson?q=${query}&max=1000`, {
             // credentials: 'same-origin',
             method: 'GET',
         })

--- a/ui/src/pages/landing.tsx
+++ b/ui/src/pages/landing.tsx
@@ -5,6 +5,7 @@ import Button from '../components/Button'
 import RecentPodcasts from '../components/RecentPodcasts'
 import { updateTitle } from '../utils'
 import StatsCard from './Stats/StatsCard'
+import { authenticatedFetch } from '../utils/auth'
 
 import './styles.scss'
 
@@ -61,10 +62,11 @@ export default class Landing extends React.Component<IProps, IState> {
     }
 
     async getRecentEpisodes() {
-        let response = await fetch(`/api/recent/episodes?max=7`, {
+        let response = await authenticatedFetch(`/api/recent/episodes?max=7`, {
             credentials: 'same-origin',
             method: 'GET',
         })
+
         return await response.json()
     }
 

--- a/ui/src/utils/auth.ts
+++ b/ui/src/utils/auth.ts
@@ -1,0 +1,107 @@
+const DEFAULT_POW_DIFFICULTY = 3;
+let cachedDifficulty = null;
+
+async function getPowDifficulty(): Promise<number> {
+  if (cachedDifficulty) return cachedDifficulty;
+
+  try {
+    const res = await fetch('/api/auth/config');
+    const { powDifficulty } = await res.json();
+    cachedDifficulty = powDifficulty ?? DEFAULT_POW_DIFFICULTY;
+    return cachedDifficulty;
+  } catch {
+    return DEFAULT_POW_DIFFICULTY;
+  }
+}
+
+/**
+ * Create a hash challenge from the request details
+ */
+async function createChallenge(method: string, url: string, timestamp: string): Promise<string> {
+  const urlObj = new URL(url, window.location.origin);
+  const data = `${method.toUpperCase()}|${urlObj.pathname}${urlObj.search}|${timestamp}`;
+
+  const dataBuffer = new TextEncoder().encode(data);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', dataBuffer);
+  const hashArray = new Uint8Array(hashBuffer);
+
+  return Array.from(hashArray)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Solve proof-of-work puzzle using Web Worker
+ */
+async function solvePOW(challenge: string, difficulty: number): Promise<{ nonce: string; hash: string }> {
+  const workerCode = `
+    self.onmessage = async function(e) {
+      const { challenge, difficulty } = e.data;
+      const prefix = '0'.repeat(difficulty);
+      const encoder = new TextEncoder();
+
+      for (let nonce = 0; nonce < 10000000; nonce++) {
+        const data = encoder.encode(challenge + nonce);
+        const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+        const hash = Array.from(new Uint8Array(hashBuffer))
+          .map(b => b.toString(16).padStart(2, '0'))
+          .join('');
+
+        if (hash.startsWith(prefix)) {
+          self.postMessage({ nonce: nonce.toString(), hash });
+          return;
+        }
+      }
+
+      self.postMessage({ error: 'Failed to solve POW' });
+    };
+  `;
+
+  return new Promise((resolve, reject) => {
+    const blob = new Blob([workerCode], { type: 'application/javascript' });
+    const worker = new Worker(URL.createObjectURL(blob));
+
+    worker.onmessage = (e) => {
+      worker.terminate();
+      if (e.data.error) {
+        reject(new Error(e.data.error));
+      } else {
+        resolve(e.data);
+      }
+    };
+
+    worker.onerror = (error) => {
+      worker.terminate();
+      reject(new Error('POW worker failed: ' + error.message));
+    };
+
+    worker.postMessage({ challenge, difficulty });
+  });
+}
+
+/**
+ * Make authenticated fetch request with POW
+ */
+export async function authenticatedFetch(url: string, options: RequestInit = {}): Promise<Response> {
+  const difficulty = await getPowDifficulty();
+  if (difficulty === 0) {
+    return fetch(url, options); // POW is disabled, so just fetch the URL
+  }
+
+  const method = options.method || 'GET';
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+
+  // Create and solve challenge
+  const challenge = await createChallenge(method, url, timestamp);
+  const { nonce, hash } = await solvePOW(challenge, difficulty);
+
+  // Add auth headers
+  const headers = {
+    ...options.headers,
+    'X-POW-Nonce': nonce,
+    'X-POW-Hash': hash,
+    'X-POW-Timestamp': timestamp,
+  };
+
+  return fetch(url, { ...options, headers });
+}


### PR DESCRIPTION
Proof of Work challenges seem to be the latest way to combat AI scraping of websites. This PR implements a challenge that takes time for a client to complete, but takes no time for the server to verify. 

In this case, the client hashes the http method, path, and timestamp and then generates hashes of the hash and generated nonces in an attempt to find a hash with enough leading zeros to satisfy the POW_DIFFICULTY. The server verifies the hash by hashing the http method, path, and timestamp with the nonce and comparing the resulting hash with the one given by the client.

This seems to work fine, but might make the site feel a bit sluggish if the difficulty is set up too high. Conversely, too much AI bot traffic might make it through if the difficulty is set too low.

The POW_DIFFICULTY is set in the .env file and I tested it with a difficulty of 3. Setting the POW_DIFFICULTY to zero disables the challenge.