### PR TITLE
Expose webpack's dev server outside the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ yarn install
 
 # Start dev server
 yarn run dev
+# Or if you are using docker (to bind to 0.0.0.0 instead of loopback)
+# yarn run dev:docker
 
 # Start the node server in another terminal window.
 yarn run start

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     },
     "scripts": {
         "dev": "webpack-dev-server --env.file=development --mode development --devtool inline-source-map",
+        "dev:docker": "yarn run dev --host=0.0.0.0",
         "build": "webpack",
         "production": "NODE_ENV='production' && webpack --env.file=production --mode production && node server",
         "start": "node server",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,6 @@ module.exports = env => ({
         contentBase: path.join(__dirname, './server/www'),
         compress: true,
         port: 9001,
-        host: '0.0.0.0',
         historyApiFallback: true,
         proxy: {
             '/': {


### PR DESCRIPTION
This is needed to be able to use the `dev` environment inside a container

https://www.okteto.com/docs/tutorials/webpack/

https://dev.to/ku6ryo/run-webpackdevserver-in-docker-1mg5

Another option would it be to have multiple `webpack.dev.js` files.

https://webpack.js.org/guides/production/
https://www.dashdashforce.dev/posts/webpack-configs-for-prod

EDIT:
Changed to create an alias script instead of hardcoded on `webpack.config.js`