### PR TITLE
rss.com remoteitem

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -2000,6 +2000,10 @@
         "elementURL": "https://changelog.rss.com/v24-6-1-294338"
       },
       {
+        "elementName": "Remote Item",
+        "elementURL": "https://changelog.rss.com/v24-6-1-294338"
+      },
+      {
         "elementName": "Alternate Enclosure",
         "elementURL": "https://changelog.rss.com/v26-2-1-331741"
       }


### PR DESCRIPTION
RSS.com supports podroll, so by default they support remote item.