### PR TITLE
Use tagLine as image tooltip

### DIFF
--- a/ui/src/pages/Apps/AppsWebPart/SingleApp/index.tsx
+++ b/ui/src/pages/Apps/AppsWebPart/SingleApp/index.tsx
@@ -9,6 +9,8 @@ function SingleApp(app) {
                 <div className="podcastIndexAppIcon">
                     <img
                         src={`${document.location.origin}/api/images/${app.appIconUrl}`}
+                        alt=''
+                        {...(app.tagLine ? { title: `${app.tagLine}` } : {})}
                     ></img>
                 </div>
                 <div className="podcastIndexAppTitleAndType">


### PR DESCRIPTION
As far as I see, `tagLine` it's not used anywhere.
Try to use it on the image, but also mark the images as not informative for screen readers with `alt=''`