### PR TITLE
Fountain Support for `<podcast:contentLink>`

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -453,6 +453,9 @@
       },
       {
         "elementName": "Remote Item"
+      },
+      {
+        "elementName": "Content Link"
       }
     ]
   },


### PR DESCRIPTION
Fountain-hosted RSS feeds now link to Fountain episode and track pages via `<podcast:contentLink>`: [example](https://feeds.fountain.fm/ATJJiXjYcgUsrblu8fIi)