### PR TITLE
Add a link to the daily report

### DIFF
--- a/ui/src/pages/Stats/index.tsx
+++ b/ui/src/pages/Stats/index.tsx
@@ -87,6 +87,7 @@ export default class Card extends React.Component<IProps> {
                     last90={overallStats.feedCount90days}
                 />
             </div>
+          <div style="text-align:center;">Get an <a href="https://public.podcastindex.org/24hourFeedReport.html">overview of all new feeds</a> over the last 24 hours.</div>
         )
     }
 }


### PR DESCRIPTION
This just adds a link to the daily report, which should probably be linked-to from here.