### PR TITLE
Add RadaRadio app details to apps.json

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -4191,7 +4191,7 @@
    {
     "appName": "RadaRadio",
     "appType": ["app", "hosting", "website", "podcast player", "radio player"],
-    "appUrl": "https://radaradio.com.com",
+    "appUrl": "https://radaradio.com/",
     "appIconUrl": "radaradio.png",
     "platforms": ["Web", "Mobile"],
     "platformLinks": {

--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -4187,5 +4187,39 @@
         "elementName": "Episode"
       }
     ]
-  }
+  },
+   {
+    "appName": "RadaRadio",
+    "appType": ["app", "hosting", "website", "podcast player", "radio player"],
+    "appUrl": "https://radaradio.com.com",
+    "appIconUrl": "radaradio.png",
+    "platforms": ["Web", "Mobile"],
+    "platformLinks": {
+        "Web": "https://radaradio.com/",
+        "Android": "https://play.google.com/store/apps/details?id=com.radaradio.app",
+        "iOS": "https://apps.apple.com/app/radaradio-fm-radio-podcast/id6761927629"
+    },
+    "supportedElements": [
+      {
+        "elementName": "Chapters",
+        "elementURL": "https://radaradio.com/podcast?sort=popular"
+      },
+      {
+        "elementName": "Episode"
+      },
+      {
+        "elementName": "Medium"
+      },
+      {
+        "elementName": "Podping"
+      },
+      {
+        "elementName": "Season"
+      },
+      {
+        "elementName": "Search",
+        "elementURL": "https://radaradio.com/podcast?search=podcastindex"
+      }
+    ]
+  },
 ]


### PR DESCRIPTION
This PR adds RadaRadio to the Podcast Index apps directory.

App info
Name: RadaRadio
Website: https://radaradio.com
Logo : https://cdn.radaradio.com/radaradio.png
Type: podcast player/app
Platforms: Web, iOS, Android
