### PR TITLE
Fix unwrapped JSX and HTML-style style attribute on Stats page

### DIFF
--- a/ui/src/pages/Stats/index.tsx
+++ b/ui/src/pages/Stats/index.tsx
@@ -86,8 +86,10 @@ export default class Card extends React.Component<IProps> {
                     last60={overallStats.feedCount60days}
                     last90={overallStats.feedCount90days}
                 />
+                <div style={{ textAlign: 'center' }}>
+                    Get an <a href="https://public.podcastindex.org/24hourFeedReport.html">overview of all new feeds</a> over the last 24 hours.
+                </div>
             </div>
-          <div style="text-align:center;">Get an <a href="https://public.podcastindex.org/24hourFeedReport.html">overview of all new feeds</a> over the last 24 hours.</div>
         )
     }
 }


### PR DESCRIPTION
The 24-hour-report link div was placed outside the wrapping landing-content div and used HTML string syntax for its style attribute. Production builds caught this with TS2657 (multiple parent elements), TS2559 (string vs CSSProperties), and a cascading TS2695 from the same parser confusion.