### PR TITLE
Catch errors fetching ActivityPub comments

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -266,27 +266,32 @@ app.use('/api/comments/byepisodeid', powMiddleware, async (req, res) => {
 
   const sentCommenters = {}
 
-  const threadcap = await makeThreadcap(socialInteract[0].uri, {
-    userAgent,
-    cache,
-    fetcher,
-  })
+  try {
+    const threadcap = await makeThreadcap(socialInteract[0].uri, {
+      userAgent,
+      cache,
+      fetcher,
+    })
 
-  const callbacks = {
-    onEvent: (e) => {
-      if (e.kind === 'node-processed' && e.part === 'replies') {
-        writeThreadcapChunk(e.nodeId, threadcap, sentCommenters, res)
-      }
-    },
+    const callbacks = {
+      onEvent: (e) => {
+        if (e.kind === 'node-processed' && e.part === 'replies') {
+          writeThreadcapChunk(e.nodeId, threadcap, sentCommenters, res)
+        }
+      },
+    }
+
+    await updateThreadcap(threadcap, {
+      updateTime: new Date().toISOString(),
+      userAgent,
+      cache,
+      fetcher,
+      callbacks,
+    })
+  } catch (error) {
+    console.error('Error fetching ActivityPub comments:', error)
+    res.status(500).send('Error fetching ActivityPub comments')
   }
-
-  await updateThreadcap(threadcap, {
-    updateTime: new Date().toISOString(),
-    userAgent,
-    cache,
-    fetcher,
-    callbacks,
-  })
 
   res.end()
 })


### PR DESCRIPTION
Added an exception handler around the threadcap code to handle bad responses from ActivityPub servers. e.g.:

```
/home/ericpp/podcastindex/web-ui/node_modules/threadcap/cjs/main.js:762
    throw new Error(`Expected 200 response for ${url}, found ${status} body=${bodyText}`);
          ^

Error: Expected 200 response for https://floss.social/@kde_espana/115321582436666775, found 401 body={"error":"Request not signed"}
    at findOrFetchJson (/home/ericpp/podcastindex/web-ui/node_modules/threadcap/cjs/main.js:762:11)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async findOrFetchActivityPubObject (/home/ericpp/podcastindex/web-ui/node_modules/threadcap/cjs/main.js:822:10)
    at async Object.initActivityPubThreadcap [as initThreadcap] (/home/ericpp/podcastindex/web-ui/node_modules/threadcap/cjs/main.js:826:18)
    at async makeThreadcap (/home/ericpp/podcastindex/web-ui/node_modules/threadcap/cjs/main.js:1283:10)
    at async /home/ericpp/podcastindex/web-ui/server/index.js:269:21
[HPM] Error occurred while trying to proxy request /api/comments/byepisodeid?id=45094455020 from localhost:9001 to http://localhost:5001 (ECONNRESET) (https://nodejs.org/api/errors.html#errors_common_system_errors)
```

Related to #583 #432
