### PR TITLE
Add Dev Container configuration for Codespaces/VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,11 @@
 {
   "name": "podcastindex-web-ui",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:1-16-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    }
+  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "podcastindex-web-ui",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-16-bullseye",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "esbenp.prettier-vscode"
+      ]
+    }
+  },
+  "forwardPorts": [9001, 5001],
+  "portsAttributes": {
+    "9001": {
+      "label": "webpack-dev-server (UI)",
+      "onAutoForward": "openPreview"
+    },
+    "5001": {
+      "label": "express API server",
+      "onAutoForward": "notify"
+    }
+  },
+  "containerEnv": {
+    "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"
+  },
+  "postCreateCommand": "sudo corepack enable && corepack prepare yarn@3.4.1 --activate && { [ -f .env ] || cp .env-example .env; } && { [ -f .environments/.env.development ] || cp .env-example .environments/.env.development; } && yarn install",
+  "remoteUser": "node"
+}


### PR DESCRIPTION
Adds `.devcontainer/devcontainer.json` so the repo opens ready to go in GitHub Codespaces or VS Code Dev Containers (closes #553).

It pins Node 16 to match `.nvmrc`, activates yarn 3.4.1 through Corepack (with sudo, since the base image ships a root-owned yarn 1.22 symlink that corepack has to replace), seeds `.env` and `.environments/.env.development` from `.env-example` when they're missing (same steps the README describes, both gitignored), forwards 9001/5001 for `yarn run dev` and `yarn start`, and includes the sshd feature so terminal access (`gh codespace ssh`) works against the container. Plain `yarn run dev` works in-container because port forwarding attaches from inside; the `dev:docker` script from #524 is still the one to use with raw docker.

Two deliberate omissions: no format-on-save (much of the tree isn't currently Prettier-clean, so saves would produce noisy unrelated diffs) and no ESLint extension (the repo has no ESLint config).

Tested end-to-end on a real Codespace (2-core basicLinux32gb): postCreate completed cleanly (corepack, env seeding, `yarn install` in about 2.5 minutes cold), `node -v` reports v16.20.2 and `yarn -v` reports 3.4.1, and both servers booted and answered on their forwarded ports (`/api/auth/config` on 5001 and webpack-dev-server on 9001, both HTTP 200). One note from the run: `sharp` compiles from source during install rather than pulling a prebuilt binary; it adds a little install time but completes without errors.
