### PR TITLE
Use lightning: URI for V4V lnaddress links, keep well-known as fallback

### DIFF
--- a/ui/src/components/Value/index.tsx
+++ b/ui/src/components/Value/index.tsx
@@ -25,17 +25,43 @@ export default class Value extends React.PureComponent<IProps, PodState> {
     super(props);
   }
 
+  getLnAddressParts(dest: any): [string, string] | null {
+    const match = dest.address.toLowerCase().match(/^([a-z0-9._-]+)@([a-z0-9.-]+)$/);
+    return match ? [match[1], match[2]] : null;
+  }
+
   getLink(dest: any): string {
     if (dest.type === "lnaddress") {
-      const match = dest.address.toLowerCase().match(/^([a-z0-9._-]+)@([a-z0-9.-]+)$/);
+      const parts = this.getLnAddressParts(dest);
 
-      if (match) {
-        const [ _, username, domain ] = match;
-        return "https://" + domain + "/.well-known/lnurlp/" + username;
+      if (parts) {
+        const [ username, domain ] = parts;
+        // "lightning:" is intercepted by wallet extensions (e.g. Alby) the
+        // same way "mailto:" is intercepted by a mail client, so this is
+        // the more useful click target than the raw well-known URL. See
+        // https://github.com/Podcastindex-org/web-ui/issues/494
+        return "lightning:" + username + "@" + domain;
       }
     }
 
     return "https://amboss.space/node/" + dest.address;
+  }
+
+  // For lnaddress destinations, a secondary link to the raw LNURL-pay
+  // well-known JSON, for anyone without a wallet extension who wants to
+  // inspect the payment endpoint directly.
+  getWellKnownLink(dest: any): string | null {
+    if (dest.type !== "lnaddress") {
+      return null;
+    }
+
+    const parts = this.getLnAddressParts(dest);
+    if (!parts) {
+      return null;
+    }
+
+    const [ username, domain ] = parts;
+    return "https://" + domain + "/.well-known/lnurlp/" + username;
   }
 
   render() {
@@ -57,13 +83,25 @@ export default class Value extends React.PureComponent<IProps, PodState> {
       <div className="podcast-value">
         <h4>Value for Value via {titleizeString(model.type)}</h4>
         <ul>
-          {destinations.map(dest => (
-            <li key={dest.name}>
-              <progress value={dest.split} max={splitTotal} title={dest.address}></progress>
-              {knownDeadNodes[dest.address] && <span title={`This ${knownDeadNodes[dest.address]} wallet is no longer active. If this is your feed, please update it with a new wallet address.`}>⚠️</span>}
-              <a target="_blank" href={this.getLink(dest)}>{dest.name}</a>
-            </li>
-          ))}
+          {destinations.map(dest => {
+            const wellKnownLink = this.getWellKnownLink(dest)
+
+            return (
+              <li key={dest.name}>
+                <progress value={dest.split} max={splitTotal} title={dest.address}></progress>
+                {knownDeadNodes[dest.address] && <span title={`This ${knownDeadNodes[dest.address]} wallet is no longer active. If this is your feed, please update it with a new wallet address.`}>⚠️</span>}
+                <a target="_blank" href={this.getLink(dest)}>{dest.name}</a>
+                {wellKnownLink &&
+                  <a
+                    className="lnaddress-details"
+                    target="_blank"
+                    href={wellKnownLink}
+                    title="View Lightning Address details (LNURL-pay well-known endpoint)"
+                  >ⓘ</a>
+                }
+              </li>
+            )
+          })}
         </ul>
       </div>
     )

--- a/ui/src/components/Value/styles.scss
+++ b/ui/src/components/Value/styles.scss
@@ -40,6 +40,17 @@
     background-color: var(--color-primary);
     border-radius: .25rem;
   }
+
+  .lnaddress-details {
+    margin-left: .35rem;
+    font-size: .85em;
+    opacity: .65;
+    text-decoration: none;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
 }
 
 @media only screen and (max-width: 767px) {


### PR DESCRIPTION
Addresses the design question in #494: for `lnaddress` Value4Value destinations, the link now uses a `lightning:username@domain` URI instead of the raw LNURL-pay well-known URL, so wallet extensions (Alby, etc.) can intercept the click the same way `mailto:` is intercepted by a mail client.

The original well-known URL is still available as a small secondary "â“˜" link next to the destination name, for anyone without a wallet extension who wants to see the raw LNURL-pay JSON (this was Brian's ask in the thread: "a little JSON and a link to the well-known").

Non-lnaddress destinations (raw node pubkeys) are unchanged.

## Screenshots

Screenshots are from a local dev build with mock data (no API keys set up in that checkout).

**Before** â€” link points at the raw well-known URL:

<img src="https://raw.githubusercontent.com/conorbronsdon/web-ui/pr-assets/before.png" width="420" alt="Before: V4V lightning link pointing at the raw LNURL-pay well-known URL">

**After** â€” link uses a `lightning:` URI, well-known URL kept as a secondary info link:

<img src="https://raw.githubusercontent.com/conorbronsdon/web-ui/pr-assets/after.png" width="420" alt="After: V4V lightning link using a lightning: URI, with a secondary info icon linking to the well-known URL">
