### PR TITLE
Add Docker Compose file for local development

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,35 @@
+services:
+  init:
+    image: node:16
+    command: [ "bash", "-c", "corepack enable && yarn install" ]
+    volumes:
+      - .:/app
+    working_dir: /app
+
+  dev:
+    image: node:16
+    command: [ "yarn", "run", "dev:docker"]
+    environment:
+      - PROXY_TARGET=http://server:5001
+    ports:
+      - "9001:9001"
+    volumes:
+      - .:/app
+    working_dir: /app
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    restart: on-failure
+
+  server:
+    image: node:16
+    command: [ "yarn", "run", "start" ]
+    # ports:
+    #   - "5001:5001"
+    volumes:
+      - .:/app
+    working_dir: /app
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    restart: on-failure

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin')
 const Dotenv = require('dotenv-webpack');
 
+const proxyTarget = process.env.PROXY_TARGET || 'http://localhost:5001';
+
 module.exports = env => ({
     watch: false,
     mode: 'production',
@@ -15,22 +17,22 @@ module.exports = env => ({
         proxy: {
             '/': {
                 changeOrigin: true,
-                target: 'http://localhost:5001',
+                target: proxyTarget,
                 pathRewrite: { '^/': '/' },
             },
             '/api': {
                 changeOrigin: true,
-                target: 'http://localhost:5001',
+                target: proxyTarget,
                 pathRewrite: { '^/api': '/api' },
             },
             '/namespace': {
                 changeOrigin: true,
-                target: 'http://localhost:5001',
+                target: proxyTarget,
                 pathRewrite: { '^/namespace': '/namespace' },
             },
             '/podcast': {
                 changeOrigin: true,
-                target: 'http://localhost:5001',
+                target: proxyTarget,
                 pathRewrite: { '^/podcast': '/podcast' },
             }
         },


### PR DESCRIPTION
Adds a **compose.yaml** file to make it easier to locally develop the website.

To use this with Docker Compose:

1. Create your `.env` file in the main directory (using .env-example as an example).
2. Run `docker compose up` to install node dependencies and launch the webpack dev and express servers.

Also adds a PROXY_TARGET env variable so that the webpack dev container can proxy connections to the express container.

Related #516 