### PR TITLE
Add Alternate Enclosure support to Pocket Casts

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -177,6 +177,9 @@
     },
     "supportedElements": [
       {
+        "elementName": "Alternate Enclosure"
+      },
+      {
         "elementName": "Chapters",
         "elementURL": "https://blog.pocketcasts.com/2024/04/16/artwork-and-chapters/"
       },


### PR DESCRIPTION
Pocket Casts now supports Alternate Enclosure. Adding it to their supported elements list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)