### PR TITLE
Update Podpage supported elements

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -2863,15 +2863,15 @@
         "elementURL": "https://www.podpage.com/updates/podcasting-20/"
       },
       {
+        "elementName": "Chapters",
+        "elementURL": "https://www.podpage.com/updates/podcasting-20/"
+      },
+      {
         "elementName": "Funding",
         "elementURL": "https://www.podpage.com/updates/podcasting-20/"
       },
       {
         "elementName": "Person",
-        "elementURL": "https://www.podpage.com/updates/podcasting-20/"
-      },
-      {
-        "elementName": "Trailer",
         "elementURL": "https://www.podpage.com/updates/podcasting-20/"
       },
       {
@@ -2884,6 +2884,30 @@
       },
       {
         "elementName": "GUID",
+        "elementURL": "https://www.podpage.com/updates/podcasting-20/"
+      },
+      {
+        "elementName": "Alternate Enclosure",
+        "elementURL": "https://www.podpage.com/updates/podcasting-20/"
+      },
+      {
+        "elementName": "Trailer",
+        "elementURL": "https://www.podpage.com/updates/podcasting-20/"
+      },
+      {
+        "elementName": "Podroll",
+        "elementURL": "https://www.podpage.com/updates/podcasting-20/"
+      },
+      {
+        "elementName": "Remote Item",
+        "elementURL": "https://www.podpage.com/updates/podcasting-20/"
+      },
+      {
+        "elementName": "Podping",
+        "elementURL": "https://www.podpage.com/updates/podcasting-20/"
+      },
+      {
+        "elementName": "Search",
         "elementURL": "https://www.podpage.com/updates/podcasting-20/"
       }
     ]


### PR DESCRIPTION
Podpage's entry has been stale — it lists 7 elements but we've been consuming more than that for a while, and just added one more.

Adding:

- **Chapters** — `podcast:chapters` is fetched, parsed and rendered as a chapters tab on every episode page
- **Alternate Enclosure** — `podcast:alternateEnclosure` + `podcast:source` are read for video/HLS enclosures and become the episode's video player
- **Podroll** / **Remote Item** — `podcast:podroll` is parsed, each `podcast:remoteItem` feed is fetched for its artwork and title, and the result renders as a Podroll page on the site
- **Podping** — we run a Hive watcher and trigger an immediate feed sync on a matching ping, rather than waiting for the next poll
- **Search** — full-text episode search on every Podpage site
- **Trailer** — `podcast:trailer` is imported as a trailer episode and can be featured in the site header (previously we only honored `itunes:episodeType`, so this is genuinely new)

No removals.