### PR TITLE
Add iOS App Store link for Car Curious

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -4307,11 +4307,14 @@
   },
   {
     "appName": "Car Curious",
-    "appType": ["website"],
+    "appType": ["website", "podcast player", "app"],
     "tagLine": "Smart annotations and searchable transcripts for automotive podcasts",
     "appUrl": "https://getcarcurious.com",
     "appIconUrl": "carcurious.png",
-    "platforms": ["Web"],
+    "platforms": ["Web", "iOS"],
+    "platformLinks": {
+      "iOS": "https://apps.apple.com/us/app/car-curious/id6785778025"
+    },
     "supportedElements": [
       {
         "elementName": "Transcript"


### PR DESCRIPTION
Car Curious shipped on the App Store since the original listing went in (#551). This adds the iOS platform and App Store link.

- Adds "iOS" to platforms
- Adds platformLinks.iOS pointing to https://apps.apple.com/us/app/car-curious/id6785778025