### PR TITLE
Add Podcast Index node to the dead wallet list

### DIFF
--- a/ui/src/components/Value/index.tsx
+++ b/ui/src/components/Value/index.tsx
@@ -50,7 +50,8 @@ export default class Value extends React.PureComponent<IProps, PodState> {
     const knownDeadNodes = {
       "030a58b8653d32b99200a2334cfe913e51dc7d155aa0116c176657a4f1722677a3": "Alby",
       "0332d57355d673e217238ce3e4be8491aa6b2a13f95494133ee243e57df1653ace": "Fountain",
-      "03bc290b26637eb8f25de69fca83c85c014796aa03d90bf0d4c03c18947e12127d": "Fountain"
+      "03bc290b26637eb8f25de69fca83c85c014796aa03d90bf0d4c03c18947e12127d": "Fountain",
+      "03ae9f91a0cb8ff43840e3c322c4c61f019d8c1c3cea15a25cfc425ac605e61a4a": "Podcast Index",
     }
 
     return (


### PR DESCRIPTION
Add the old Podcast Index node to the dead wallet list so that it gets flagged on podcast pages. 
<img width="1133" height="540" alt="image" src="https://github.com/user-attachments/assets/aee7cc3b-b82a-4963-b85f-b305068e25c8" />
